### PR TITLE
Feature book note refactor

### DIFF
--- a/src/components/bookNote/ExButton.tsx
+++ b/src/components/bookNote/ExButton.tsx
@@ -4,14 +4,14 @@ import { IcRightArrow } from "../../assets/icons";
 
 interface ExButtonProps {
   idx: number;
-  onToggleDrawer: (i: number) => void;
+  onOpenDrawer: (i: number) => void;
 }
 
 export default function ExButton(props: ExButtonProps) {
-  const { idx, onToggleDrawer } = props;
+  const { idx, onOpenDrawer } = props;
 
   return (
-    <StButton type="button" onClick={() => onToggleDrawer(idx)}>
+    <StButton type="button" onClick={() => onOpenDrawer(idx)}>
       예시
       <StIcon />
     </StButton>

--- a/src/components/bookNote/periNote/Complete.tsx
+++ b/src/components/bookNote/periNote/Complete.tsx
@@ -22,6 +22,7 @@ interface CompleteProps {
 export default function Complete(props: CompleteProps) {
   const navigate = useNavigate();
   const { bookData, isLoginState } = props;
+
   const { authors, publicationDt, thumbnail, title, translators } = bookData;
   const { fromUrl } = isLoginState;
 

--- a/src/components/bookNote/periNote/PeriNote.tsx
+++ b/src/components/bookNote/periNote/PeriNote.tsx
@@ -15,7 +15,7 @@ import PeriModal from "../stepUp/PeriModal";
 export default function PeriNote() {
   const [
     isLogin,
-    handleToggleDrawer,
+    handleOpenDrawer,
     preNote,
     handleChangeReview,
     setOpenModal,
@@ -129,7 +129,7 @@ export default function PeriNote() {
             <StLabel>질문 리스트를 구조화하며 책을 읽어보세요.</StLabel>
             <StepUp onToggleModal={handlePeriCarousel} />
           </StLabelContainer>
-          <ExButton idx={4} onToggleDrawer={handleToggleDrawer} />
+          <ExButton idx={4} onOpenDrawer={handleOpenDrawer} />
         </StLabelWrapper>
         <StQAWrapper>
           {periNote.map((question0, a) => (

--- a/src/components/bookNote/periNote/PeriNote.tsx
+++ b/src/components/bookNote/periNote/PeriNote.tsx
@@ -124,6 +124,16 @@ export default function PeriNote() {
         }
       });
     });
+
+    const inputList = document.getElementsByTagName("input");
+
+    for (let i = 0; i < inputList.length; i++) {
+      if (i === 1) {
+        inputList[1].focus();
+      } else {
+        inputList[i].blur();
+      }
+    }
   }, []);
 
   return (

--- a/src/components/bookNote/periNote/PeriNote.tsx
+++ b/src/components/bookNote/periNote/PeriNote.tsx
@@ -29,6 +29,7 @@ export default function PeriNote() {
     fromUrl,
     reviewId,
     isAdded,
+    handleAutoFocus,
   ] =
     useOutletContext<
       [
@@ -47,6 +48,7 @@ export default function PeriNote() {
         string,
         number,
         boolean,
+        () => void,
       ]
     >();
 
@@ -102,6 +104,7 @@ export default function PeriNote() {
   const handleEnterAdd = (event: React.KeyboardEvent<HTMLInputElement>, idxList: number[]) => {
     if (event.key === "Enter") {
       handleAddPeri(idxList);
+      handleAutoFocus();
     }
   };
 
@@ -172,7 +175,7 @@ export default function PeriNote() {
                           handleChangePeri("answer", event.target.value, [a, b]);
                         }}
                         onKeyPress={(event) => handleEnterAdd(event, [a])}
-                        autoFocus={isAdded}
+                        autoFocus={!isAdded}
                       />
                       <StMoreIcon onClick={handleToggle} />
                       <StMiniMenu menuposition={"isPriA"}>
@@ -223,7 +226,7 @@ export default function PeriNote() {
                                   value={answer1.text}
                                   onChange={(event) => handleChangePeri("answer", event.target.value, [a, b, c, d])}
                                   onKeyPress={(event) => handleEnterAdd(event, [a, b, c])}
-                                  autoFocus={isAdded}
+                                  autoFocus={!isAdded}
                                 />
                                 <StMoreIcon onClick={handleToggle} />
                                 <StMiniMenu>
@@ -277,7 +280,7 @@ export default function PeriNote() {
                                             handleChangePeri("answer", event.target.value, [a, b, c, d, e, f])
                                           }
                                           onKeyPress={(event) => handleEnterAdd(event, [a, b, c, d, e])}
-                                          autoFocus={isAdded}
+                                          autoFocus={!isAdded}
                                         />
                                         <StMoreIcon onClick={handleToggle} />
                                         <StMiniMenu>
@@ -352,7 +355,7 @@ export default function PeriNote() {
                                                     ])
                                                   }
                                                   onKeyPress={(event) => handleEnterAdd(event, [a, b, c, d, e, f, g])}
-                                                  autoFocus={isAdded}
+                                                  autoFocus={!isAdded}
                                                 />
                                                 <StMoreIcon onClick={handleToggle} />
                                                 <StMiniMenu>
@@ -439,7 +442,7 @@ export default function PeriNote() {
                                                           onKeyPress={(event) =>
                                                             handleEnterAdd(event, [a, b, c, d, e, f, g, h, i])
                                                           }
-                                                          autoFocus={isAdded}
+                                                          autoFocus={!isAdded}
                                                         />
                                                         <StMoreIcon onClick={handleToggle} />
                                                         <StMiniMenu>

--- a/src/components/bookNote/periNote/PeriNote.tsx
+++ b/src/components/bookNote/periNote/PeriNote.tsx
@@ -27,7 +27,6 @@ export default function PeriNote() {
     handleDeletePeri,
     userToken,
     fromUrl,
-    patchReview,
     reviewId,
   ] =
     useOutletContext<
@@ -45,7 +44,6 @@ export default function PeriNote() {
         (idxList: number[]) => void,
         string,
         string,
-        () => Promise<void>,
         number,
       ]
     >();

--- a/src/components/bookNote/periNote/PeriNote.tsx
+++ b/src/components/bookNote/periNote/PeriNote.tsx
@@ -73,7 +73,6 @@ export default function PeriNote() {
       progress,
     });
 
-    console.log("data", data);
     setBookData(data.data.bookData);
   };
 

--- a/src/components/bookNote/periNote/PeriNote.tsx
+++ b/src/components/bookNote/periNote/PeriNote.tsx
@@ -73,6 +73,7 @@ export default function PeriNote() {
       progress,
     });
 
+    console.log("data", data);
     setBookData(data.data.bookData);
   };
 

--- a/src/components/bookNote/periNote/PeriNote.tsx
+++ b/src/components/bookNote/periNote/PeriNote.tsx
@@ -28,6 +28,7 @@ export default function PeriNote() {
     userToken,
     fromUrl,
     reviewId,
+    isAdded,
   ] =
     useOutletContext<
       [
@@ -45,6 +46,7 @@ export default function PeriNote() {
         string,
         string,
         number,
+        boolean,
       ]
     >();
 
@@ -144,6 +146,7 @@ export default function PeriNote() {
                     setIsDisabled(event.target.value === "");
                     handleChangePeri("question", event.target.value, [a]);
                   }}
+                  autoFocus={isAdded}
                 />
                 <StAddAnswerButton type="button" onClick={() => handleAddPeri([a])}>
                   답변
@@ -169,6 +172,7 @@ export default function PeriNote() {
                           handleChangePeri("answer", event.target.value, [a, b]);
                         }}
                         onKeyPress={(event) => handleEnterAdd(event, [a])}
+                        autoFocus={isAdded}
                       />
                       <StMoreIcon onClick={handleToggle} />
                       <StMiniMenu menuposition={"isPriA"}>
@@ -196,6 +200,7 @@ export default function PeriNote() {
                                 key={`q1-${c}`}
                                 value={question1.question}
                                 onChange={(event) => handleChangePeri("question", event.target.value, [a, b, c])}
+                                autoFocus={isAdded}
                               />
                               <StAddAnswerButton type="button" onClick={() => handleAddPeri([a, b, c])}>
                                 답변
@@ -218,6 +223,7 @@ export default function PeriNote() {
                                   value={answer1.text}
                                   onChange={(event) => handleChangePeri("answer", event.target.value, [a, b, c, d])}
                                   onKeyPress={(event) => handleEnterAdd(event, [a, b, c])}
+                                  autoFocus={isAdded}
                                 />
                                 <StMoreIcon onClick={handleToggle} />
                                 <StMiniMenu>
@@ -246,6 +252,7 @@ export default function PeriNote() {
                                         onChange={(event) =>
                                           handleChangePeri("question", event.target.value, [a, b, c, d, e])
                                         }
+                                        autoFocus={isAdded}
                                       />
                                       <StAddAnswerButton type="button" onClick={() => handleAddPeri([a, b, c, d, e])}>
                                         답변
@@ -270,6 +277,7 @@ export default function PeriNote() {
                                             handleChangePeri("answer", event.target.value, [a, b, c, d, e, f])
                                           }
                                           onKeyPress={(event) => handleEnterAdd(event, [a, b, c, d, e])}
+                                          autoFocus={isAdded}
                                         />
                                         <StMoreIcon onClick={handleToggle} />
                                         <StMiniMenu>
@@ -306,6 +314,7 @@ export default function PeriNote() {
                                                     g,
                                                   ])
                                                 }
+                                                autoFocus={isAdded}
                                               />
                                               <StAddAnswerButton
                                                 type="button"
@@ -343,6 +352,7 @@ export default function PeriNote() {
                                                     ])
                                                   }
                                                   onKeyPress={(event) => handleEnterAdd(event, [a, b, c, d, e, f, g])}
+                                                  autoFocus={isAdded}
                                                 />
                                                 <StMoreIcon onClick={handleToggle} />
                                                 <StMiniMenu>
@@ -387,6 +397,7 @@ export default function PeriNote() {
                                                             i,
                                                           ])
                                                         }
+                                                        autoFocus={isAdded}
                                                       />
                                                       <StAddAnswerButton
                                                         type="button"
@@ -428,6 +439,7 @@ export default function PeriNote() {
                                                           onKeyPress={(event) =>
                                                             handleEnterAdd(event, [a, b, c, d, e, f, g, h, i])
                                                           }
+                                                          autoFocus={isAdded}
                                                         />
                                                         <StMoreIcon onClick={handleToggle} />
                                                         <StMiniMenu>

--- a/src/components/bookNote/preNote/InputQuestion.tsx
+++ b/src/components/bookNote/preNote/InputQuestion.tsx
@@ -9,14 +9,29 @@ interface InputQuestionProps {
   onDelete: (idx: number) => void;
   isPrevented: boolean;
   isAdded: boolean;
+  onAddInput: () => void;
 }
 
 export default function InputQuestion(props: InputQuestionProps) {
-  const { idx, value, onChangeValue, onDelete, isPrevented, isAdded } = props;
+  const { idx, value, onChangeValue, onDelete, isPrevented, isAdded, onAddInput } = props;
+
+  const addInputByEnter = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (isPrevented) return;
+
+    if (e.key === "Enter") {
+      onAddInput();
+    }
+  };
 
   return (
     <StWrapper>
-      <StInput placeholder="질문 입력" value={value} onChange={(e) => onChangeValue(e, idx)} autoFocus={isAdded} />
+      <StInput
+        placeholder="질문 입력"
+        value={value}
+        onChange={(e) => onChangeValue(e, idx)}
+        autoFocus={isAdded}
+        onKeyPress={addInputByEnter}
+      />
       {!isPrevented ? <StIcon onClick={() => onDelete(idx)} /> : ""}
     </StWrapper>
   );

--- a/src/components/bookNote/preNote/InputQuestion.tsx
+++ b/src/components/bookNote/preNote/InputQuestion.tsx
@@ -8,14 +8,15 @@ interface InputQuestionProps {
   onChangeValue: (e: React.ChangeEvent<HTMLInputElement>, idx: number) => void;
   onDelete: (idx: number) => void;
   isPrevented: boolean;
+  isAdded: boolean;
 }
 
 export default function InputQuestion(props: InputQuestionProps) {
-  const { idx, value, onChangeValue, onDelete, isPrevented } = props;
+  const { idx, value, onChangeValue, onDelete, isPrevented, isAdded } = props;
 
   return (
     <StWrapper>
-      <StInput placeholder="질문 입력" value={value} onChange={(e) => onChangeValue(e, idx)} />
+      <StInput placeholder="질문 입력" value={value} onChange={(e) => onChangeValue(e, idx)} autoFocus={isAdded} />
       {!isPrevented ? <StIcon onClick={() => onDelete(idx)} /> : ""}
     </StWrapper>
   );

--- a/src/components/bookNote/preNote/PreNote.tsx
+++ b/src/components/bookNote/preNote/PreNote.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from "react";
 import { useNavigate, useOutletContext } from "react-router-dom";
 import styled, { css } from "styled-components";
 
@@ -20,7 +19,6 @@ export default function PreNote() {
         boolean,
       ]
     >();
-  const [isFilled, setIsFilled] = useState<boolean>(false);
   const { answerOne, answerTwo, questionList } = preNote;
 
   const onChangeReview = (key: string, value: string | string[] | number): void => {
@@ -39,9 +37,9 @@ export default function PreNote() {
   const localNick = localStorage.getItem("booktez-nickname");
   const nickname = isLogin && localNick ? localNick : "익명의 독서가";
 
-  useEffect(() => {
-    setIsFilled(!questionList.includes(""));
-  }, [questionList]);
+  // useEffect(() => {
+  //   setIsFilled(!questionList.includes(""));
+  // }, [questionList]);
 
   return (
     <StNoteForm onSubmit={(e) => e.preventDefault()}>
@@ -73,7 +71,7 @@ export default function PreNote() {
             onChangeReview={onChangeReview}
             onToggleDrawer={handleToggleDrawer}
             isPrevented={isPrevented}
-            isFilled={isFilled}
+            ablePatch={ablePatch}
           />
         ) : (
           <StLinkWrapper>
@@ -88,7 +86,7 @@ export default function PreNote() {
       </StFormWrapper>
 
       {/* 모든 내용이 채워졌을 때 버튼이 활성화되도록 하기 */}
-      <StNextBtn type="button" disabled={!ablePatch || !isFilled} onClick={handleSubmit}>
+      <StNextBtn type="button" disabled={!ablePatch} onClick={handleSubmit}>
         다음 계단
       </StNextBtn>
     </StNoteForm>

--- a/src/components/bookNote/preNote/PreNote.tsx
+++ b/src/components/bookNote/preNote/PreNote.tsx
@@ -7,7 +7,7 @@ import { PreNoteForm, QuestionThree } from "..";
 
 export default function PreNote() {
   const navigate = useNavigate();
-  const [isLogin, handleToggleDrawer, preNote, handleChangeReview, setOpenModal, isPrevented, ablePatch] =
+  const [isLogin, handleOpenDrawer, preNote, handleChangeReview, setOpenModal, isPrevented, ablePatch] =
     useOutletContext<
       [
         boolean,
@@ -21,10 +21,6 @@ export default function PreNote() {
     >();
   const { answerOne, answerTwo, questionList } = preNote;
 
-  const onChangeReview = (key: string, value: string | string[] | number): void => {
-    handleChangeReview(key, value);
-  };
-
   const handleSubmit = () => {
     setOpenModal(true);
   };
@@ -37,10 +33,6 @@ export default function PreNote() {
   const localNick = localStorage.getItem("booktez-nickname");
   const nickname = isLogin && localNick ? localNick : "익명의 독서가";
 
-  // useEffect(() => {
-  //   setIsFilled(!questionList.includes(""));
-  // }, [questionList]);
-
   return (
     <StNoteForm onSubmit={(e) => e.preventDefault()}>
       <StFormHead>책을 넘기기 전 독서전략을 세워보아요.</StFormHead>
@@ -48,28 +40,28 @@ export default function PreNote() {
         <PreNoteForm
           question={`${nickname}님은 이 책에 어떤 기대를 하고 계신가요?`}
           idx={1}
-          onToggleDrawer={handleToggleDrawer}>
+          onOpenDrawer={handleOpenDrawer}>
           <StTextarea
             placeholder="답변을 입력해주세요."
             value={answerOne}
-            onChange={(e) => onChangeReview("answerOne", e.target.value)}
+            onChange={(e) => handleChangeReview("answerOne", e.target.value)}
           />
         </PreNoteForm>
         <PreNoteForm
           question="이 책의 핵심 메시지는 무엇일까요? 그 중 어느 부분들이 기대를 만족시킬 수 있을까요? "
           idx={2}
-          onToggleDrawer={handleToggleDrawer}>
+          onOpenDrawer={handleOpenDrawer}>
           <StTextarea
             placeholder="답변을 입력해주세요."
             value={answerTwo}
-            onChange={(e) => onChangeReview("answerTwo", e.target.value)}
+            onChange={(e) => handleChangeReview("answerTwo", e.target.value)}
           />
         </PreNoteForm>
         {isLogin ? (
           <QuestionThree
             questionList={questionList}
-            onChangeReview={onChangeReview}
-            onToggleDrawer={handleToggleDrawer}
+            onChangeReview={handleChangeReview}
+            onOpenDrawer={handleOpenDrawer}
             isPrevented={isPrevented}
             ablePatch={ablePatch}
           />

--- a/src/components/bookNote/preNote/PreNote.tsx
+++ b/src/components/bookNote/preNote/PreNote.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useNavigate, useOutletContext } from "react-router-dom";
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 
 import { PreNoteData } from "../../../pages/BookNote";
 import { Button } from "../../common/styled/Button";
@@ -88,11 +88,7 @@ export default function PreNote() {
       </StFormWrapper>
 
       {/* 모든 내용이 채워졌을 때 버튼이 활성화되도록 하기 */}
-      <StNextBtn
-        type="button"
-        disabled={!ablePatch || !isFilled}
-        onClick={handleSubmit}
-        isdisabled={!ablePatch || !isFilled}>
+      <StNextBtn type="button" disabled={!ablePatch || !isFilled} onClick={handleSubmit}>
         다음 계단
       </StNextBtn>
     </StNoteForm>
@@ -137,15 +133,21 @@ const StTextarea = styled.textarea`
   }
 `;
 
-const StNextBtn = styled(Button)<{ isdisabled: boolean }>`
+const StNextBtn = styled(Button)<{ disabled: boolean }>`
   margin-top: 10rem;
   padding: 1.6rem 13rem;
   border-radius: 1rem;
-  background-color: ${({ isdisabled, theme }) => (isdisabled ? theme.colors.white400 : theme.colors.orange100)};
+  background-color: ${({ disabled, theme }) => (disabled ? theme.colors.white400 : theme.colors.orange100)};
 
   width: 32.5rem;
-  color: ${({ isdisabled, theme }) => (isdisabled ? theme.colors.gray300 : theme.colors.white)};
+  color: ${({ disabled, theme }) => (disabled ? theme.colors.gray300 : theme.colors.white)};
   ${({ theme }) => theme.fonts.button};
+
+  ${({ disabled }) =>
+    disabled &&
+    css`
+      cursor: default;
+    `}
 `;
 
 const StLinkWrapper = styled.section`

--- a/src/components/bookNote/preNote/PreNote.tsx
+++ b/src/components/bookNote/preNote/PreNote.tsx
@@ -1,8 +1,8 @@
+import { useEffect, useState } from "react";
 import { useNavigate, useOutletContext } from "react-router-dom";
 import styled from "styled-components";
 
 import { PreNoteData } from "../../../pages/BookNote";
-import { Question } from "../../../utils/dataType";
 import { Button } from "../../common/styled/Button";
 import { PreNoteForm, QuestionThree } from "..";
 
@@ -20,6 +20,7 @@ export default function PreNote() {
         boolean,
       ]
     >();
+  const [isFilled, setIsFilled] = useState<boolean>(false);
   const { answerOne, answerTwo, questionList } = preNote;
 
   const onChangeReview = (key: string, value: string | string[] | number): void => {
@@ -37,6 +38,10 @@ export default function PreNote() {
 
   const localNick = localStorage.getItem("booktez-nickname");
   const nickname = isLogin && localNick ? localNick : "익명의 독서가";
+
+  useEffect(() => {
+    setIsFilled(!questionList.includes(""));
+  }, [questionList]);
 
   return (
     <StNoteForm onSubmit={(e) => e.preventDefault()}>
@@ -68,6 +73,7 @@ export default function PreNote() {
             onChangeReview={onChangeReview}
             onToggleDrawer={handleToggleDrawer}
             isPrevented={isPrevented}
+            isFilled={isFilled}
           />
         ) : (
           <StLinkWrapper>
@@ -82,7 +88,11 @@ export default function PreNote() {
       </StFormWrapper>
 
       {/* 모든 내용이 채워졌을 때 버튼이 활성화되도록 하기 */}
-      <StNextBtn type="button" disabled={!ablePatch} onClick={handleSubmit} isdisabled={!ablePatch}>
+      <StNextBtn
+        type="button"
+        disabled={!ablePatch || !isFilled}
+        onClick={handleSubmit}
+        isdisabled={!ablePatch || !isFilled}>
         다음 계단
       </StNextBtn>
     </StNoteForm>

--- a/src/components/bookNote/preNote/PreNoteForm.tsx
+++ b/src/components/bookNote/preNote/PreNoteForm.tsx
@@ -9,12 +9,12 @@ import ThreeCaseModal from "../stepUp/ThreeCaseModal";
 interface PreNoteFormProps {
   question: string;
   idx: number;
-  onToggleDrawer: (i: number) => void;
+  onOpenDrawer: (i: number) => void;
   children: React.ReactNode;
 }
 
 export default function PreNoteForm(props: PreNoteFormProps) {
-  const { question, idx, onToggleDrawer, children } = props;
+  const { question, idx, onOpenDrawer, children } = props;
 
   const [openModal, setOpenModal] = useState<boolean>(false);
 
@@ -30,7 +30,7 @@ export default function PreNoteForm(props: PreNoteFormProps) {
             {question}
             <StepUp onToggleModal={onToggleModal} />
           </StH3>
-          <ExButton idx={idx} onToggleDrawer={onToggleDrawer} />
+          <ExButton idx={idx} onOpenDrawer={onOpenDrawer} />
         </StHeader>
         <StArticle>{children}</StArticle>
       </StSection>

--- a/src/components/bookNote/preNote/PreNoteForm.tsx
+++ b/src/components/bookNote/preNote/PreNoteForm.tsx
@@ -16,6 +16,7 @@ interface PreNoteFormProps {
 export default function PreNoteForm(props: PreNoteFormProps) {
   const { question, idx, onOpenDrawer, children } = props;
 
+  // periNote의 handlePeriCarousel과 동일
   const [openModal, setOpenModal] = useState<boolean>(false);
 
   const onToggleModal = useCallback(() => {

--- a/src/components/bookNote/preNote/QuestionThree.tsx
+++ b/src/components/bookNote/preNote/QuestionThree.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import styled, { css } from "styled-components";
 
 import { InputQuestion, PreNoteForm } from "..";
@@ -13,7 +14,10 @@ interface QuestionThreeProps {
 export default function QuestionThree(props: QuestionThreeProps) {
   const { questionList, onChangeReview, onOpenDrawer, isPrevented, ablePatch } = props;
 
+  const [isAdded, setIsAdded] = useState<boolean>(false);
+
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>, idx: number) => {
+    setIsAdded(true);
     const modified = [...questionList];
 
     modified[idx] = e.target.value;
@@ -30,6 +34,7 @@ export default function QuestionThree(props: QuestionThreeProps) {
   const addInput = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     e.preventDefault();
     onChangeReview("questionList", [...questionList, ""]);
+    setIsAdded(true);
   };
 
   return (
@@ -42,6 +47,7 @@ export default function QuestionThree(props: QuestionThreeProps) {
           onChangeValue={handleChange}
           onDelete={handleDelete}
           isPrevented={isPrevented}
+          isAdded={isAdded}
         />
       ))}
       {!isPrevented ? (

--- a/src/components/bookNote/preNote/QuestionThree.tsx
+++ b/src/components/bookNote/preNote/QuestionThree.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from "react";
 import styled from "styled-components";
 
 import { InputQuestion, PreNoteForm } from "..";
@@ -8,11 +7,11 @@ interface QuestionThreeProps {
   onChangeReview: (key: string, value: string | string[] | number) => void;
   onToggleDrawer: (i: number) => void;
   isPrevented: boolean;
+  isFilled: boolean;
 }
 
 export default function QuestionThree(props: QuestionThreeProps) {
-  const { questionList, onChangeReview, onToggleDrawer, isPrevented } = props;
-  const [isFilled, setIsFilled] = useState(false);
+  const { questionList, onChangeReview, onToggleDrawer, isPrevented, isFilled } = props;
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>, idx: number) => {
     const modified = [...questionList];
@@ -32,10 +31,6 @@ export default function QuestionThree(props: QuestionThreeProps) {
     e.preventDefault();
     onChangeReview("questionList", [...questionList, ""]);
   };
-
-  useEffect(() => {
-    setIsFilled(!questionList.includes(""));
-  }, [questionList]);
 
   return (
     <PreNoteForm question="가장 관심가는 주제부터 질문 리스트를 만들어보세요!" idx={3} onToggleDrawer={onToggleDrawer}>

--- a/src/components/bookNote/preNote/QuestionThree.tsx
+++ b/src/components/bookNote/preNote/QuestionThree.tsx
@@ -7,11 +7,11 @@ interface QuestionThreeProps {
   onChangeReview: (key: string, value: string | string[] | number) => void;
   onToggleDrawer: (i: number) => void;
   isPrevented: boolean;
-  isFilled: boolean;
+  ablePatch: boolean;
 }
 
 export default function QuestionThree(props: QuestionThreeProps) {
-  const { questionList, onChangeReview, onToggleDrawer, isPrevented, isFilled } = props;
+  const { questionList, onChangeReview, onToggleDrawer, isPrevented, ablePatch } = props;
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>, idx: number) => {
     const modified = [...questionList];
@@ -45,7 +45,7 @@ export default function QuestionThree(props: QuestionThreeProps) {
         />
       ))}
       {!isPrevented ? (
-        <StAddButton type="button" disabled={!isFilled} onClick={addInput}>
+        <StAddButton type="button" disabled={!ablePatch} onClick={addInput}>
           + 질문추가
         </StAddButton>
       ) : (

--- a/src/components/bookNote/preNote/QuestionThree.tsx
+++ b/src/components/bookNote/preNote/QuestionThree.tsx
@@ -5,13 +5,13 @@ import { InputQuestion, PreNoteForm } from "..";
 interface QuestionThreeProps {
   questionList: string[];
   onChangeReview: (key: string, value: string | string[] | number) => void;
-  onToggleDrawer: (i: number) => void;
+  onOpenDrawer: (i: number) => void;
   isPrevented: boolean;
   ablePatch: boolean;
 }
 
 export default function QuestionThree(props: QuestionThreeProps) {
-  const { questionList, onChangeReview, onToggleDrawer, isPrevented, ablePatch } = props;
+  const { questionList, onChangeReview, onOpenDrawer, isPrevented, ablePatch } = props;
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>, idx: number) => {
     const modified = [...questionList];
@@ -33,7 +33,7 @@ export default function QuestionThree(props: QuestionThreeProps) {
   };
 
   return (
-    <PreNoteForm question="가장 관심가는 주제부터 질문 리스트를 만들어보세요!" idx={3} onToggleDrawer={onToggleDrawer}>
+    <PreNoteForm question="가장 관심가는 주제부터 질문 리스트를 만들어보세요!" idx={3} onOpenDrawer={onOpenDrawer}>
       {questionList.map((question, idx) => (
         <InputQuestion
           key={idx}

--- a/src/components/bookNote/preNote/QuestionThree.tsx
+++ b/src/components/bookNote/preNote/QuestionThree.tsx
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 
 import { InputQuestion, PreNoteForm } from "..";
 
@@ -45,7 +45,7 @@ export default function QuestionThree(props: QuestionThreeProps) {
         />
       ))}
       {!isPrevented ? (
-        <StAddButton type="button" disabled={!isFilled} onClick={addInput} isfilled={isFilled}>
+        <StAddButton type="button" disabled={!isFilled} onClick={addInput}>
           + 질문추가
         </StAddButton>
       ) : (
@@ -55,7 +55,7 @@ export default function QuestionThree(props: QuestionThreeProps) {
   );
 }
 
-const StAddButton = styled.button<{ isfilled: boolean }>`
+const StAddButton = styled.button<{ disabled: boolean }>`
   margin-right: 9.1rem;
   border: 0.2rem solid ${({ theme }) => theme.colors.white400};
   border-radius: 0.8rem;
@@ -63,7 +63,13 @@ const StAddButton = styled.button<{ isfilled: boolean }>`
   background-color: ${({ theme }) => theme.colors.white200};
 
   width: calc(100% - 5rem);
-  color: ${({ isfilled, theme }) => (isfilled ? theme.colors.gray100 : theme.colors.white500)};
+  color: ${({ disabled, theme }) => (!disabled ? theme.colors.gray100 : theme.colors.white500)};
   text-align: start;
   ${({ theme }) => theme.fonts.body4}
+
+  ${({ disabled }) =>
+    disabled &&
+    css`
+      cursor: default;
+    `}
 `;

--- a/src/components/bookNote/preNote/QuestionThree.tsx
+++ b/src/components/bookNote/preNote/QuestionThree.tsx
@@ -31,8 +31,7 @@ export default function QuestionThree(props: QuestionThreeProps) {
     onChangeReview("questionList", newArray);
   };
 
-  const addInput = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-    e.preventDefault();
+  const handleAddInput = () => {
     onChangeReview("questionList", [...questionList, ""]);
     setIsAdded(true);
   };
@@ -48,10 +47,11 @@ export default function QuestionThree(props: QuestionThreeProps) {
           onDelete={handleDelete}
           isPrevented={isPrevented}
           isAdded={isAdded}
+          onAddInput={handleAddInput}
         />
       ))}
       {!isPrevented ? (
-        <StAddButton type="button" disabled={!ablePatch} onClick={addInput}>
+        <StAddButton type="button" disabled={!ablePatch} onClick={handleAddInput}>
           + 질문추가
         </StAddButton>
       ) : (

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -3,6 +3,7 @@ export { default as CommonLayout } from "./CommonLayout";
 export { default as Error404 } from "./Error404";
 export { default as InputEmail } from "./InputEmail";
 export { default as InputPwd } from "./InputPwd";
+export { default as Loading } from "./Loading";
 export { default as MainHeader } from "./MainHeader";
 export { default as MainLayout } from "./MainLayout";
 export { default as NavHeader } from "./NavHeader";

--- a/src/components/detail/ExamplePreNote.tsx
+++ b/src/components/detail/ExamplePreNote.tsx
@@ -15,7 +15,7 @@ interface ExamplePreNoteProps {
 export default function ExamplePreNote(props: ExamplePreNoteProps) {
   const { answerOne, answerTwo, questionList, isLogin } = props;
   const navigate = useNavigate();
-  const nickname = "냠냠"; // 닉네임 받아오기(로컬스토리지)
+  const nickname = localStorage.getItem("booktez-nickname"); // 닉네임 받아오기(로컬스토리지)
 
   const handleGoSignup = () => {
     navigate("/signup", { state: "rightpath" });

--- a/src/components/signup/SecondStep.tsx
+++ b/src/components/signup/SecondStep.tsx
@@ -1,4 +1,3 @@
-import axios from "axios";
 import { useEffect, useState } from "react";
 import { useNavigate, useOutletContext } from "react-router-dom";
 import styled, { css } from "styled-components";

--- a/src/pages/BookNote.tsx
+++ b/src/pages/BookNote.tsx
@@ -4,8 +4,7 @@ import styled, { css, keyframes } from "styled-components";
 
 import { IcCheckSave, IcSave } from "../assets/icons";
 import { DrawerWrapper, Navigator, PopUpPreDone } from "../components/bookNote";
-import { PopUpExit } from "../components/common";
-import Loading from "../components/common/Loading";
+import { Loading, PopUpExit } from "../components/common";
 import { StIcCancelWhite } from "../components/common/styled/NoteModalWrapper";
 import { Question } from "../utils/dataType";
 import { getData, patchData } from "../utils/lib/api";
@@ -29,22 +28,21 @@ export interface PreNoteData extends ObjKey {
 
 export default function BookNote() {
   const navigate = useNavigate();
-  const { pathname, state } = useLocation();
 
+  // 현재 페이지를 확인하여 navigator를 움직이고 patch할 때 필요한 아이들
+  const { pathname, state } = useLocation();
   const initIndex = pathname === "/book-note/peri" ? 1 : 0;
   const pathKey = initIndex ? "now" : "before";
   const [navIndex, setNavIndex] = useState<number>(initIndex);
 
+  // recoil로 관리하면 어떨까?
   const isLoginState = state as IsLoginState;
   const { isLogin, reviewId, fromUrl } = isLoginState;
 
   const TOKEN = localStorage.getItem("booktez-token");
   const userToken = TOKEN ? TOKEN : "";
 
-  const [isPrevented, setIsPrevented] = useState<boolean>(false);
-  const [ablePatch, setAblePatch] = useState<boolean>(false);
-  const [openModal, setOpenModal] = useState<boolean>(false);
-  const [title, setTitle] = useState<string>("");
+  // pre/peri note 데이터가 들어갈 곳
   const [preNote, setPreNote] = useState<PreNoteData>({
     answerOne: "",
     answerTwo: "",
@@ -52,16 +50,27 @@ export default function BookNote() {
     progress: 2,
   });
   const [periNote, setPeriNote] = useState<Question[]>([]);
-  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [title, setTitle] = useState<string>("");
+
+  const [isPrevented, setIsPrevented] = useState<boolean>(false);
+  const [ablePatch, setAblePatch] = useState<boolean>(false);
+
+  const [openModal, setOpenModal] = useState<boolean>(false);
+
+  const [openExitModal, setOpenExitModal] = useState<boolean>(false);
+
   const [drawerIdx, setDrawerIdx] = useState(1);
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+
   const [isSave, setIsSave] = useState<boolean>(false);
+
+  const [isLoading, setIsLoading] = useState<boolean>(true);
 
   const handleNav = (idx: number) => {
     setNavIndex(idx);
   };
 
-  const handleToggleDrawer = (i: number) => {
+  const handleOpenDrawer = (i: number) => {
     setIsDrawerOpen(true);
     setDrawerIdx(i);
   };
@@ -164,6 +173,7 @@ export default function BookNote() {
   const handleSubmit = async () => {
     handleChangeReview("progress", 3);
     patchReview(pathKey, { ...preNote, progress: 3 });
+    // 현재 periNote의 내용을 저장해야 함
     patchReview("now", { answerThree: { root: periNote }, progress: 3 });
     setIsPrevented(true);
 
@@ -202,6 +212,7 @@ export default function BookNote() {
     };
   }, [saveReview]);
 
+  // 똥페리 switch문
   const handleChangePeri = (key: string, value: string, idxList: number[]) => {
     const newRoot = [...periNote];
 
@@ -385,8 +396,6 @@ export default function BookNote() {
     getReview();
   }, []);
 
-  const [openExitModal, setOpenExitModal] = useState<boolean>(false);
-
   const handleExit = () => {
     setOpenExitModal(!openExitModal);
   };
@@ -418,7 +427,7 @@ export default function BookNote() {
         <Outlet
           context={[
             isLogin,
-            handleToggleDrawer,
+            handleOpenDrawer,
             preNote,
             handleChangeReview,
             setOpenModal,
@@ -462,12 +471,11 @@ const StNoteModalWrapper = styled.section<{ isopen: boolean; width: number }>`
 
   min-height: 100vh;
   ${({ isopen, width }) =>
-    isopen
-      ? css`
-          animation: ${reducewidth(width)} 300ms linear 1;
-          animation-fill-mode: forwards;
-        `
-      : ""}
+    isopen &&
+    css`
+      animation: ${reducewidth(width)} 300ms linear 1;
+      animation-fill-mode: forwards;
+    `}
 `;
 
 const StNavWrapper = styled.div`

--- a/src/pages/BookNote.tsx
+++ b/src/pages/BookNote.tsx
@@ -37,7 +37,7 @@ export default function BookNote() {
   const { pathname, state } = useLocation();
 
   const initIndex = pathname === "/book-note/peri" ? 1 : 0;
-  const pathKey = pathname === "/book-note" ? "before" : "now";
+  const pathKey = initIndex ? "now" : "before";
   const [navIndex, setNavIndex] = useState<number>(initIndex);
 
   const isLoginState = state as IsLoginState;
@@ -91,7 +91,6 @@ export default function BookNote() {
     try {
       // 비회원인 경우
       // 로컬스토리지에서 책 정보를 불러옴 - okay
-      // 로컬스토리지에서 리뷰 정보를 불러옴 - yet
       if (!isLogin) {
         const localData = localStorage.getItem("booktez-bookData");
         const bookTitle = localData ? JSON.parse(localData).title : "";
@@ -106,10 +105,13 @@ export default function BookNote() {
         setTitle(bookTitle);
         setPreNote({ answerOne, answerTwo, questionList: questions, progress: reviewState });
 
+        // console.log("answerThree", answerThree);
+        // answerThree가 null이 아닌 경우
         if (answerThree) {
           setPeriNote(answerThree.root);
         } else {
-          // answerThree가 비어있을 때 독서 전의 질문 동기화
+          console.log("answerThree is null");
+          // answerThree가 비어있을 때(null) 독서 전의 질문 동기화
           // 한 번 동기화되고 나서는 빈 상태가 아니라서 동기화되지 않음
           const defaultQuestions: Question[] = [];
 
@@ -119,6 +121,7 @@ export default function BookNote() {
           setPeriNote(defaultQuestions);
         }
 
+        // 독서 중으로 넘어간 경우
         if (reviewState > 2) {
           setIsPrevented(true);
           setAblePatch(true);
@@ -155,7 +158,9 @@ export default function BookNote() {
 
   // 저장만 하기 - 수정 완료는 아님
   const saveReview = async () => {
-    const progress = pathKey === "before" ? 2 : 3;
+    // initIndex가 1이면 progress는 3, 0이면 progress는 2
+
+    const progress = preNote.progress === 4 ? 4 : initIndex + 2;
     const body = pathKey === "before" ? { ...preNote, progress } : { answerThree: { root: periNote }, progress };
 
     patchReview(pathKey, body);
@@ -177,13 +182,6 @@ export default function BookNote() {
     navigate("/book-note/peri", { state: isLoginState });
     // navigator 변경
     handleNav(1);
-
-    const defaultQuestions: Question[] = [];
-
-    preNote.questionList.map((question: string) =>
-      defaultQuestions.push({ depth: 1, question, answer: [{ text: "", children: [] }] }),
-    );
-    setPeriNote(defaultQuestions);
   };
 
   // 모달 내 '취소' 버튼 - 모달을 끄는 용도

--- a/src/pages/BookNote.tsx
+++ b/src/pages/BookNote.tsx
@@ -66,6 +66,8 @@ export default function BookNote() {
 
   const [isLoading, setIsLoading] = useState<boolean>(true);
 
+  const [isAdded, setIsAdded] = useState<boolean>(false);
+
   const handleNav = (idx: number) => {
     setNavIndex(idx);
   };
@@ -331,6 +333,7 @@ export default function BookNote() {
     }
 
     setPeriNote(newRoot);
+    setIsAdded(true);
   };
 
   const handleDeletePeri = (idxList: number[]) => {
@@ -440,6 +443,7 @@ export default function BookNote() {
             userToken,
             fromUrl,
             reviewId,
+            isAdded,
           ]}
         />
       )}

--- a/src/pages/BookNote.tsx
+++ b/src/pages/BookNote.tsx
@@ -66,7 +66,7 @@ export default function BookNote() {
 
   const [isLoading, setIsLoading] = useState<boolean>(true);
 
-  const [isAdded, setIsAdded] = useState<boolean>(false);
+  const [isAdded, setIsAdded] = useState<boolean>(true);
 
   const handleNav = (idx: number) => {
     setNavIndex(idx);

--- a/src/pages/BookNote.tsx
+++ b/src/pages/BookNote.tsx
@@ -385,6 +385,16 @@ export default function BookNote() {
     setPeriNote(newRoot);
   };
 
+  const handleExit = () => {
+    setOpenExitModal(!openExitModal);
+  };
+
+  // 꼬리 질문 추가에서는 질문에만 focus가 되도록 answer에는 autoFocus가 반대로 적용되어 있음
+  // Enter에 대해서, 즉 답변만 추가될 때는 답변에만 focus가 되도록 하기
+  const handleAutoFocus = () => {
+    setIsAdded(false);
+  };
+
   useEffect(() => {
     // 질문 리스트가 비어있으면 다음단계 버튼 비활성화(ablePatch <- false)
     // 그렇지 않으면 true
@@ -398,10 +408,6 @@ export default function BookNote() {
   useEffect(() => {
     getReview();
   }, []);
-
-  const handleExit = () => {
-    setOpenExitModal(!openExitModal);
-  };
 
   return (
     <StNoteModalWrapper isopen={isDrawerOpen} width={pathname === "/book-note/peri" ? 60 : 39}>
@@ -444,6 +450,7 @@ export default function BookNote() {
             fromUrl,
             reviewId,
             isAdded,
+            handleAutoFocus,
           ]}
         />
       )}

--- a/src/pages/BookNote.tsx
+++ b/src/pages/BookNote.tsx
@@ -428,7 +428,6 @@ export default function BookNote() {
             handleDeletePeri,
             userToken,
             fromUrl,
-            patchReview,
             reviewId,
           ]}
         />

--- a/src/pages/BookNote.tsx
+++ b/src/pages/BookNote.tsx
@@ -172,7 +172,7 @@ export default function BookNote() {
     // 드로워 닫기
     setIsDrawerOpen(false);
 
-    if (!periNote[0].question) {
+    if (preNote.progress === 2) {
       const defaultQuestions: Question[] = [];
 
       preNote.questionList.map((question: string) =>

--- a/src/pages/BookNote.tsx
+++ b/src/pages/BookNote.tsx
@@ -104,7 +104,6 @@ export default function BookNote() {
         if (answerThree) {
           setPeriNote(answerThree.root);
         } else {
-          console.log("answerThree is null");
           // answerThree가 비어있을 때(null) 독서 전의 질문 동기화
           // 한 번 동기화되고 나서는 빈 상태가 아니라서 동기화되지 않음
           const defaultQuestions: Question[] = [];
@@ -172,6 +171,15 @@ export default function BookNote() {
     setOpenModal(false);
     // 드로워 닫기
     setIsDrawerOpen(false);
+
+    if (!periNote[0].question) {
+      const defaultQuestions: Question[] = [];
+
+      preNote.questionList.map((question: string) =>
+        defaultQuestions.push({ depth: 1, question, answer: [{ text: "", children: [] }] }),
+      );
+      setPeriNote(defaultQuestions);
+    }
 
     // peri로 넘어가기
     navigate("/book-note/peri", { state: isLoginState });
@@ -374,12 +382,6 @@ export default function BookNote() {
   useEffect(() => {
     getReview();
   }, []);
-
-  useEffect(() => {
-    if (navIndex === 1) {
-      console.log(periNote);
-    }
-  }, [navIndex]);
 
   const [openExitModal, setOpenExitModal] = useState<boolean>(false);
 

--- a/src/pages/BookNote.tsx
+++ b/src/pages/BookNote.tsx
@@ -376,6 +376,8 @@ export default function BookNote() {
     // 그렇지 않으면 true
     if (preNote.answerOne && preNote.answerTwo && !preNote.questionList.includes("")) {
       setAblePatch(true);
+    } else {
+      setAblePatch(false);
     }
   }, [preNote]);
 

--- a/src/pages/BookNote.tsx
+++ b/src/pages/BookNote.tsx
@@ -27,11 +27,6 @@ export interface PreNoteData extends ObjKey {
   progress: number;
 }
 
-interface AnswerThree {
-  root: Question[];
-  progress: number;
-}
-
 export default function BookNote() {
   const navigate = useNavigate();
   const { pathname, state } = useLocation();
@@ -89,8 +84,7 @@ export default function BookNote() {
     // get 요청 시작할 시 loading 시작
     setIsLoading(true);
     try {
-      // 비회원인 경우
-      // 로컬스토리지에서 책 정보를 불러옴 - okay
+      // 비회원인 경우, 로컬스토리지에서 책 정보를 불러옴
       if (!isLogin) {
         const localData = localStorage.getItem("booktez-bookData");
         const bookTitle = localData ? JSON.parse(localData).title : "";
@@ -171,6 +165,7 @@ export default function BookNote() {
   const handleSubmit = async () => {
     handleChangeReview("progress", 3);
     patchReview(pathKey, { ...preNote, progress: 3 });
+    patchReview("now", { answerThree: { root: periNote }, progress: 3 });
     setIsPrevented(true);
 
     // 현재 모달 닫기
@@ -379,6 +374,12 @@ export default function BookNote() {
   useEffect(() => {
     getReview();
   }, []);
+
+  useEffect(() => {
+    if (navIndex === 1) {
+      console.log(periNote);
+    }
+  }, [navIndex]);
 
   const [openExitModal, setOpenExitModal] = useState<boolean>(false);
 


### PR DESCRIPTION
## 📌 내용
<!-- 하고 싶은 말 자유롭게 -->
- 이제 input 창에서 엔터를 치면 다음 input을 생성할 수 있습니다아!! 마구마구 테스트 부탁드려염!
- 덧붙여, 유저가 독서와 기록에만 집중할 수 있는 환경을 더 만들고 싶은데, 어떤 것이 더 들어가면 좋을지 의견 주십셔
- feature-book_note_qa에 이어서 올리고 싶었는데 왜 안올라갈까... 아니 내가 올린다는디!!! 잘 하다가 왜 안되누.. 뭐가 문제누!! PR 늘리려는거 진짜 아님 그냥 진짜 아님 진짜 안되어서 고민하다고 올리는거임 깃 좀 알려죠 난 바보야

<br />

## 📌 내가 알게 된 부분
<!-- 새롭게 알게 된 부분을 적쟈 (기록하면서 개발하기!) -->
- NodeList와 HTMLCollection은 유사 배열로, forEach, map과 같은 순회를 지원하지 않는다. for문을 사용해서 접근하거나 `Array.prototype.forEach(list, (elem, idx) => {...})`의 형태를 사용해야 한다.
[참고](https://blog.eunsatio.io/develop/Javascript%EB%A1%9C-HTML-%EC%9A%94%EC%86%8C-%EC%88%9C%ED%9A%8C%ED%95%98%EA%B8%B0)

<br />

## 📌 질문할 부분 
<!-- 작은 거라도 조아  -->
- periNote가 처음 렌더링 될 때 첫 번째 답변을 제외한 모든 input을 blur하기 위해서 input태그들을 찾고, for문을 돌면서 focus와 blur를 해주었는데, ref를 사용하면 훨씬 간단함. 결국 지금 이 방법도 document에서 select 한다는 점, 첫 렌더링 때 for문을 돈다는 점에서 별로 좋아보이지 않는데, ref 사용을 지양하려다 이상한 곳으로 온 것 같움. 어케 생각해? ref는 언제 사용하고 언제 사용하지 말아야할까?
- autoFocus와 관련해서 최대한 state를 활용해보았는데, 더 좋은 방법을 찾고 싶어.. 빨리 북노트 뿌셔서 올테니 같이 고민해줘.. 조금만 기다려쥬