### PR TITLE
Feature bookcase divide api

### DIFF
--- a/src/components/bookcase/PeriRead.tsx
+++ b/src/components/bookcase/PeriRead.tsx
@@ -19,6 +19,10 @@ export default function PeriRead() {
 
   useEffect(() => {
     getBookcasePeri("/peribook", localToken);
+
+    return () => {
+      handleIsLoading();
+    };
   }, []);
 
   const getBookcasePeri = async (key: string, token: string) => {

--- a/src/components/bookcase/PeriRead.tsx
+++ b/src/components/bookcase/PeriRead.tsx
@@ -6,11 +6,15 @@ import { getMockData } from "../../utils/lib/api";
 import Cards from "./Cards";
 
 export default function PeriRead() {
-  const [handleIsLoading, handleBookDelete, isLogin] = useOutletContext<[() => void, () => void, boolean]>();
+  const [handleIsLoading, isLogin] = useOutletContext<[() => void, boolean]>();
   const [bookcasePeri, setBookcasePeri] = useState<BookcaseInfo[]>([]);
 
   const TOKEN = localStorage.getItem("booktez-token");
   const localToken = TOKEN ? TOKEN : "";
+
+  const handleBookDelete = () => {
+    getBookcasePeri("/peribook", localToken);
+  };
 
   useEffect(() => {
     getBookcasePeri("/peribook", localToken);

--- a/src/components/bookcase/PeriRead.tsx
+++ b/src/components/bookcase/PeriRead.tsx
@@ -3,10 +3,11 @@ import { useOutletContext } from "react-router-dom";
 
 import { BookcaseInfo } from "../../pages/Bookcase";
 import { getMockData } from "../../utils/lib/api";
+import { Loading } from "../common";
 import Cards from "./Cards";
 
 export default function PeriRead() {
-  const [handleIsLoading, isLogin] = useOutletContext<[() => void, boolean]>();
+  const [isLoading, handleIsLoading, isLogin] = useOutletContext<[boolean, () => void, boolean]>();
   const [bookcasePeri, setBookcasePeri] = useState<BookcaseInfo[]>([]);
 
   const TOKEN = localStorage.getItem("booktez-token");
@@ -37,7 +38,11 @@ export default function PeriRead() {
 
   return (
     <>
-      <Cards bookcaseInfo={bookcasePeri} handleBookDelete={handleBookDelete} isLogin={isLogin} />
+      {isLoading ? (
+        <Loading />
+      ) : (
+        <Cards bookcaseInfo={bookcasePeri} handleBookDelete={handleBookDelete} isLogin={isLogin} />
+      )}
     </>
   );
 }

--- a/src/components/bookcase/PeriRead.tsx
+++ b/src/components/bookcase/PeriRead.tsx
@@ -1,11 +1,35 @@
+import { useEffect, useState } from "react";
 import { useOutletContext } from "react-router-dom";
 
 import { BookcaseInfo } from "../../pages/Bookcase";
+import { getMockData } from "../../utils/lib/api";
 import Cards from "./Cards";
 
 export default function PeriRead() {
-  const [bookcaseTotal, bookcasePre, bookcasePeri, bookcasePost, handleBookDelete, isLogin] =
-    useOutletContext<[BookcaseInfo[], BookcaseInfo[], BookcaseInfo[], BookcaseInfo[], () => void, boolean]>();
+  const [handleIsLoading, handleBookDelete, isLogin] = useOutletContext<[() => void, () => void, boolean]>();
+  const [bookcasePeri, setBookcasePeri] = useState<BookcaseInfo[]>([]);
+
+  const TOKEN = localStorage.getItem("booktez-token");
+  const localToken = TOKEN ? TOKEN : "";
+
+  useEffect(() => {
+    getBookcasePeri("/peribook", localToken);
+  }, []);
+
+  const getBookcasePeri = async (key: string, token: string) => {
+    try {
+      const {
+        data: {
+          data: { books },
+        },
+      } = await getMockData(key, token);
+
+      setBookcasePeri(books);
+    } catch (err) {
+      console.log("err", err);
+    }
+    handleIsLoading();
+  };
 
   return (
     <>

--- a/src/components/bookcase/PostRead.tsx
+++ b/src/components/bookcase/PostRead.tsx
@@ -1,11 +1,35 @@
+import { useEffect, useState } from "react";
 import { useOutletContext } from "react-router-dom";
 
 import { BookcaseInfo } from "../../pages/Bookcase";
+import { getMockData } from "../../utils/lib/api";
 import Cards from "./Cards";
 
 export default function PostRead() {
-  const [bookcaseTotal, bookcasePre, bookcasePeri, bookcasePost, handleBookDelete, isLogin] =
-    useOutletContext<[BookcaseInfo[], BookcaseInfo[], BookcaseInfo[], BookcaseInfo[], () => void, boolean]>();
+  const [handleIsLoading, handleBookDelete, isLogin] = useOutletContext<[() => void, () => void, boolean]>();
+  const [bookcasePost, setBookcasePost] = useState<BookcaseInfo[]>([]);
+
+  const TOKEN = localStorage.getItem("booktez-token");
+  const localToken = TOKEN ? TOKEN : "";
+
+  useEffect(() => {
+    getBookcasePost("/postbook", localToken);
+  }, []);
+
+  const getBookcasePost = async (key: string, token: string) => {
+    try {
+      const {
+        data: {
+          data: { books },
+        },
+      } = await getMockData(key, token);
+
+      setBookcasePost(books);
+    } catch (err) {
+      console.log("err", err);
+    }
+    handleIsLoading();
+  };
 
   return (
     <>

--- a/src/components/bookcase/PostRead.tsx
+++ b/src/components/bookcase/PostRead.tsx
@@ -3,10 +3,11 @@ import { useOutletContext } from "react-router-dom";
 
 import { BookcaseInfo } from "../../pages/Bookcase";
 import { getMockData } from "../../utils/lib/api";
+import { Loading } from "../common";
 import Cards from "./Cards";
 
 export default function PostRead() {
-  const [handleIsLoading, isLogin] = useOutletContext<[() => void, boolean]>();
+  const [isLoading, handleIsLoading, isLogin] = useOutletContext<[boolean, () => void, boolean]>();
   const [bookcasePost, setBookcasePost] = useState<BookcaseInfo[]>([]);
 
   const TOKEN = localStorage.getItem("booktez-token");
@@ -37,7 +38,11 @@ export default function PostRead() {
 
   return (
     <>
-      <Cards bookcaseInfo={bookcasePost} handleBookDelete={handleBookDelete} isLogin={isLogin} />
+      {isLoading ? (
+        <Loading />
+      ) : (
+        <Cards bookcaseInfo={bookcasePost} handleBookDelete={handleBookDelete} isLogin={isLogin} />
+      )}
     </>
   );
 }

--- a/src/components/bookcase/PostRead.tsx
+++ b/src/components/bookcase/PostRead.tsx
@@ -19,6 +19,10 @@ export default function PostRead() {
 
   useEffect(() => {
     getBookcasePost("/postbook", localToken);
+
+    return () => {
+      handleIsLoading();
+    };
   }, []);
 
   const getBookcasePost = async (key: string, token: string) => {

--- a/src/components/bookcase/PostRead.tsx
+++ b/src/components/bookcase/PostRead.tsx
@@ -6,11 +6,15 @@ import { getMockData } from "../../utils/lib/api";
 import Cards from "./Cards";
 
 export default function PostRead() {
-  const [handleIsLoading, handleBookDelete, isLogin] = useOutletContext<[() => void, () => void, boolean]>();
+  const [handleIsLoading, isLogin] = useOutletContext<[() => void, boolean]>();
   const [bookcasePost, setBookcasePost] = useState<BookcaseInfo[]>([]);
 
   const TOKEN = localStorage.getItem("booktez-token");
   const localToken = TOKEN ? TOKEN : "";
+
+  const handleBookDelete = () => {
+    getBookcasePost("/postbook", localToken);
+  };
 
   useEffect(() => {
     getBookcasePost("/postbook", localToken);

--- a/src/components/bookcase/PreRead.tsx
+++ b/src/components/bookcase/PreRead.tsx
@@ -3,10 +3,11 @@ import { useOutletContext } from "react-router-dom";
 
 import { BookcaseInfo } from "../../pages/Bookcase";
 import { getMockData } from "../../utils/lib/api";
+import { Loading } from "../common";
 import Cards from "./Cards";
 
 export default function PreRead() {
-  const [handleIsLoading, isLogin] = useOutletContext<[() => void, boolean]>();
+  const [isLoading, handleIsLoading, isLogin] = useOutletContext<[boolean, () => void, boolean]>();
   const [bookcasePre, setBookcasePre] = useState<BookcaseInfo[]>([]);
 
   const TOKEN = localStorage.getItem("booktez-token");
@@ -37,7 +38,11 @@ export default function PreRead() {
 
   return (
     <>
-      <Cards bookcaseInfo={bookcasePre} handleBookDelete={handleBookDelete} isLogin={isLogin} />
+      {isLoading ? (
+        <Loading />
+      ) : (
+        <Cards bookcaseInfo={bookcasePre} handleBookDelete={handleBookDelete} isLogin={isLogin} />
+      )}
     </>
   );
 }

--- a/src/components/bookcase/PreRead.tsx
+++ b/src/components/bookcase/PreRead.tsx
@@ -1,11 +1,35 @@
+import { useEffect, useState } from "react";
 import { useOutletContext } from "react-router-dom";
 
 import { BookcaseInfo } from "../../pages/Bookcase";
+import { getMockData } from "../../utils/lib/api";
 import Cards from "./Cards";
 
 export default function PreRead() {
-  const [bookcaseTotal, bookcasePre, bookcasePeri, bookcasePost, handleBookDelete, isLogin] =
-    useOutletContext<[BookcaseInfo[], BookcaseInfo[], BookcaseInfo[], BookcaseInfo[], () => void, boolean]>();
+  const [handleIsLoading, handleBookDelete, isLogin] = useOutletContext<[() => void, () => void, boolean]>();
+  const [bookcasePre, setBookcasePre] = useState<BookcaseInfo[]>([]);
+
+  const TOKEN = localStorage.getItem("booktez-token");
+  const localToken = TOKEN ? TOKEN : "";
+
+  useEffect(() => {
+    getBookcasePre("/prebook", localToken);
+  }, []);
+
+  const getBookcasePre = async (key: string, token: string) => {
+    try {
+      const {
+        data: {
+          data: { books },
+        },
+      } = await getMockData(key, token);
+
+      setBookcasePre(books);
+    } catch (err) {
+      console.log("err", err);
+    }
+    handleIsLoading();
+  };
 
   return (
     <>

--- a/src/components/bookcase/PreRead.tsx
+++ b/src/components/bookcase/PreRead.tsx
@@ -6,11 +6,15 @@ import { getMockData } from "../../utils/lib/api";
 import Cards from "./Cards";
 
 export default function PreRead() {
-  const [handleIsLoading, handleBookDelete, isLogin] = useOutletContext<[() => void, () => void, boolean]>();
+  const [handleIsLoading, isLogin] = useOutletContext<[() => void, boolean]>();
   const [bookcasePre, setBookcasePre] = useState<BookcaseInfo[]>([]);
 
   const TOKEN = localStorage.getItem("booktez-token");
   const localToken = TOKEN ? TOKEN : "";
+
+  const handleBookDelete = () => {
+    getBookcasePre("/prebook", localToken);
+  };
 
   useEffect(() => {
     getBookcasePre("/prebook", localToken);

--- a/src/components/bookcase/PreRead.tsx
+++ b/src/components/bookcase/PreRead.tsx
@@ -19,6 +19,10 @@ export default function PreRead() {
 
   useEffect(() => {
     getBookcasePre("/prebook", localToken);
+
+    return () => {
+      handleIsLoading();
+    };
   }, []);
 
   const getBookcasePre = async (key: string, token: string) => {

--- a/src/components/bookcase/Total.tsx
+++ b/src/components/bookcase/Total.tsx
@@ -1,11 +1,35 @@
+import { useEffect, useState } from "react";
 import { useOutletContext } from "react-router-dom";
 
 import { BookcaseInfo } from "../../pages/Bookcase";
+import { getMockData } from "../../utils/lib/api";
 import Cards from "./Cards";
 
 export default function Total() {
-  const [bookcaseTotal, bookcasePre, bookcasePeri, bookcasePost, handleBookDelete, isLogin] =
-    useOutletContext<[BookcaseInfo[], BookcaseInfo[], BookcaseInfo[], BookcaseInfo[], () => void, boolean]>();
+  const [handleIsLoading, handleBookDelete, isLogin] = useOutletContext<[() => void, () => void, boolean]>();
+  const [bookcaseTotal, setBookcaseTotal] = useState<BookcaseInfo[]>([]);
+
+  const TOKEN = localStorage.getItem("booktez-token");
+  const localToken = TOKEN ? TOKEN : "";
+
+  useEffect(() => {
+    getBookcaseTotal("/totalbook", localToken);
+  }, []);
+
+  const getBookcaseTotal = async (key: string, token: string) => {
+    try {
+      const {
+        data: {
+          data: { books },
+        },
+      } = await getMockData(key, token);
+
+      setBookcaseTotal(books);
+    } catch (err) {
+      console.log("err", err);
+    }
+    handleIsLoading();
+  };
 
   return (
     <>

--- a/src/components/bookcase/Total.tsx
+++ b/src/components/bookcase/Total.tsx
@@ -6,14 +6,18 @@ import { getMockData } from "../../utils/lib/api";
 import Cards from "./Cards";
 
 export default function Total() {
-  const [handleIsLoading, handleBookDelete, isLogin] = useOutletContext<[() => void, () => void, boolean]>();
+  const [handleIsLoading, isLogin] = useOutletContext<[() => void, boolean]>();
   const [bookcaseTotal, setBookcaseTotal] = useState<BookcaseInfo[]>([]);
 
   const TOKEN = localStorage.getItem("booktez-token");
   const localToken = TOKEN ? TOKEN : "";
 
+  const handleBookDelete = () => {
+    getBookcaseTotal("/book", localToken);
+  };
+
   useEffect(() => {
-    getBookcaseTotal("/totalbook", localToken);
+    getBookcaseTotal("/book", localToken);
   }, []);
 
   const getBookcaseTotal = async (key: string, token: string) => {

--- a/src/components/bookcase/Total.tsx
+++ b/src/components/bookcase/Total.tsx
@@ -21,9 +21,9 @@ export default function Total() {
     getBookcaseTotal("/book", localToken);
 
     return () => {
-      getBookcaseTotal("/book", localToken);
+      handleIsLoading();
     };
-  }, [bookcaseTotal]);
+  }, []);
 
   const getBookcaseTotal = async (key: string, token: string) => {
     try {

--- a/src/components/bookcase/Total.tsx
+++ b/src/components/bookcase/Total.tsx
@@ -3,10 +3,11 @@ import { useOutletContext } from "react-router-dom";
 
 import { BookcaseInfo } from "../../pages/Bookcase";
 import { getMockData } from "../../utils/lib/api";
+import { Loading } from "../common";
 import Cards from "./Cards";
 
 export default function Total() {
-  const [handleIsLoading, isLogin] = useOutletContext<[() => void, boolean]>();
+  const [isLoading, handleIsLoading, isLogin] = useOutletContext<[boolean, () => void, boolean]>();
   const [bookcaseTotal, setBookcaseTotal] = useState<BookcaseInfo[]>([]);
 
   const TOKEN = localStorage.getItem("booktez-token");
@@ -18,7 +19,11 @@ export default function Total() {
 
   useEffect(() => {
     getBookcaseTotal("/book", localToken);
-  }, []);
+
+    return () => {
+      getBookcaseTotal("/book", localToken);
+    };
+  }, [bookcaseTotal]);
 
   const getBookcaseTotal = async (key: string, token: string) => {
     try {
@@ -37,7 +42,11 @@ export default function Total() {
 
   return (
     <>
-      <Cards bookcaseInfo={bookcaseTotal} handleBookDelete={handleBookDelete} isLogin={isLogin} />
+      {isLoading ? (
+        <Loading />
+      ) : (
+        <Cards bookcaseInfo={bookcaseTotal} handleBookDelete={handleBookDelete} isLogin={isLogin} />
+      )}
     </>
   );
 }

--- a/src/components/common/MainHeader.tsx
+++ b/src/components/common/MainHeader.tsx
@@ -68,7 +68,9 @@ const StHeader = styled.header<StHeaderProps>`
 `;
 
 const StHeading2 = styled.h2`
-  ${({ theme }) => theme.fonts.header0}
+  ${({ theme }) => theme.fonts.header0};
+
+  z-index: 10;
 `;
 
 const StLoginBtn = styled(Button)<{ isMypage: string }>`

--- a/src/pages/Bookcase.tsx
+++ b/src/pages/Bookcase.tsx
@@ -15,7 +15,6 @@ export interface BookcaseInfo {
 
 export default function Bookcase() {
   const [bookcaseTotal, setBookcaseTotal] = useState<BookcaseInfo[]>([]);
-  const [bookcasePost, setBookcasePost] = useState<BookcaseInfo[]>([]);
   const [isLogin, setIsLogin] = useState<boolean>(true);
   const [isLoading, setIsLoading] = useState<boolean>(true);
 
@@ -74,7 +73,7 @@ export default function Bookcase() {
         <>
           <MainHeader>서재</MainHeader>
           <Navigation />
-          <Outlet context={[bookcaseTotal, bookcasePost, handleIsLoading, handleBookDelete, isLogin]} />
+          <Outlet context={[bookcaseTotal, handleIsLoading, handleBookDelete, isLogin]} />
         </>
       )}
     </>

--- a/src/pages/Bookcase.tsx
+++ b/src/pages/Bookcase.tsx
@@ -15,7 +15,6 @@ export interface BookcaseInfo {
 
 export default function Bookcase() {
   const [bookcaseTotal, setBookcaseTotal] = useState<BookcaseInfo[]>([]);
-  const [bookcasePeri, setBookcasePeri] = useState<BookcaseInfo[]>([]);
   const [bookcasePost, setBookcasePost] = useState<BookcaseInfo[]>([]);
   const [isLogin, setIsLogin] = useState<boolean>(true);
   const [isLoading, setIsLoading] = useState<boolean>(true);
@@ -75,7 +74,7 @@ export default function Bookcase() {
         <>
           <MainHeader>서재</MainHeader>
           <Navigation />
-          <Outlet context={[bookcaseTotal, bookcasePeri, bookcasePost, handleIsLoading, handleBookDelete, isLogin]} />
+          <Outlet context={[bookcaseTotal, bookcasePost, handleIsLoading, handleBookDelete, isLogin]} />
         </>
       )}
     </>

--- a/src/pages/Bookcase.tsx
+++ b/src/pages/Bookcase.tsx
@@ -15,7 +15,6 @@ export interface BookcaseInfo {
 
 export default function Bookcase() {
   const [bookcaseTotal, setBookcaseTotal] = useState<BookcaseInfo[]>([]);
-  const [bookcasePre, setBookcasePre] = useState<BookcaseInfo[]>([]);
   const [bookcasePeri, setBookcasePeri] = useState<BookcaseInfo[]>([]);
   const [bookcasePost, setBookcasePost] = useState<BookcaseInfo[]>([]);
   const [isLogin, setIsLogin] = useState<boolean>(true);
@@ -26,6 +25,10 @@ export default function Bookcase() {
 
   const handleBookDelete = () => {
     getBookcase("/book", localToken);
+  };
+
+  const handleIsLoading = () => {
+    setIsLoading(false);
   };
 
   useEffect(() => {
@@ -58,12 +61,6 @@ export default function Bookcase() {
       } = await getData(key, token);
 
       setBookcaseTotal(books);
-
-      books.forEach((book: BookcaseInfo) => {
-        if (book.state === 2) setBookcasePre((currentBook) => [...currentBook, book]);
-        if (book.state === 3) setBookcasePeri((currentBook) => [...currentBook, book]);
-        if (book.state === 4) setBookcasePost((currentBook) => [...currentBook, book]);
-      });
     } catch (err) {
       console.log("err", err);
     }
@@ -78,7 +75,7 @@ export default function Bookcase() {
         <>
           <MainHeader>서재</MainHeader>
           <Navigation />
-          <Outlet context={[bookcaseTotal, bookcasePre, bookcasePeri, bookcasePost, handleBookDelete, isLogin]} />
+          <Outlet context={[bookcaseTotal, bookcasePeri, bookcasePost, handleIsLoading, handleBookDelete, isLogin]} />
         </>
       )}
     </>

--- a/src/pages/Bookcase.tsx
+++ b/src/pages/Bookcase.tsx
@@ -2,8 +2,8 @@ import { useEffect, useState } from "react";
 import { Outlet } from "react-router-dom";
 
 import { Navigation } from "../components/bookcase";
-import { Loading, MainHeader } from "../components/common";
-import { getData, getMockData } from "../utils/lib/api";
+import { MainHeader } from "../components/common";
+import { getData } from "../utils/lib/api";
 
 export interface BookcaseInfo {
   author: string[];
@@ -26,7 +26,7 @@ export default function Bookcase() {
   // 코드 리뷰 후 해당 주석 삭제 예정
 
   const handleIsLoading = () => {
-    setIsLoading(false);
+    setIsLoading((e) => !e);
   };
 
   useEffect(() => {

--- a/src/pages/Bookcase.tsx
+++ b/src/pages/Bookcase.tsx
@@ -14,23 +14,21 @@ export interface BookcaseInfo {
 }
 
 export default function Bookcase() {
-  const [bookcaseTotal, setBookcaseTotal] = useState<BookcaseInfo[]>([]);
   const [isLogin, setIsLogin] = useState<boolean>(true);
   const [isLoading, setIsLoading] = useState<boolean>(true);
 
   const TOKEN = localStorage.getItem("booktez-token");
   const localToken = TOKEN ? TOKEN : "";
 
-  const handleBookDelete = () => {
-    getBookcase("/book", localToken);
-  };
+  // const handleBookDelete = () => {
+  //   getBookcase("/book", localToken);
+  // };
 
   const handleIsLoading = () => {
     setIsLoading(false);
   };
 
   useEffect(() => {
-    getBookcase("/book", localToken);
     getLogin("/auth/check", localToken);
   }, []);
 
@@ -50,21 +48,6 @@ export default function Bookcase() {
     }
   };
 
-  const getBookcase = async (key: string, token: string) => {
-    try {
-      const {
-        data: {
-          data: { books },
-        },
-      } = await getData(key, token);
-
-      setBookcaseTotal(books);
-    } catch (err) {
-      console.log("err", err);
-    }
-    setIsLoading(false);
-  };
-
   return (
     <>
       {isLogin && isLoading ? (
@@ -73,7 +56,7 @@ export default function Bookcase() {
         <>
           <MainHeader>서재</MainHeader>
           <Navigation />
-          <Outlet context={[bookcaseTotal, handleIsLoading, handleBookDelete, isLogin]} />
+          <Outlet context={[handleIsLoading, isLogin]} />
         </>
       )}
     </>

--- a/src/pages/Bookcase.tsx
+++ b/src/pages/Bookcase.tsx
@@ -3,7 +3,7 @@ import { Outlet } from "react-router-dom";
 
 import { Navigation } from "../components/bookcase";
 import { Loading, MainHeader } from "../components/common";
-import { getData } from "../utils/lib/api";
+import { getData, getMockData } from "../utils/lib/api";
 
 export interface BookcaseInfo {
   author: string[];
@@ -23,6 +23,7 @@ export default function Bookcase() {
   // const handleBookDelete = () => {
   //   getBookcase("/book", localToken);
   // };
+  // 코드 리뷰 후 해당 주석 삭제 예정
 
   const handleIsLoading = () => {
     setIsLoading(false);
@@ -50,15 +51,9 @@ export default function Bookcase() {
 
   return (
     <>
-      {isLogin && isLoading ? (
-        <Loading />
-      ) : (
-        <>
-          <MainHeader>서재</MainHeader>
-          <Navigation />
-          <Outlet context={[handleIsLoading, isLogin]} />
-        </>
-      )}
+      <MainHeader>서재</MainHeader>
+      <Navigation />
+      <Outlet context={[isLoading, handleIsLoading, isLogin]} />
     </>
   );
 }

--- a/src/utils/lib/api.ts
+++ b/src/utils/lib/api.ts
@@ -1,5 +1,5 @@
 import { KAKAOParams, PatchBody, PostBody } from "../dataType";
-import { client, KAKAO } from ".";
+import { client, KAKAO, mockClient } from ".";
 
 export const searchBook = (params: KAKAOParams) => {
   return KAKAO.get("/v3/search/book", { params });
@@ -9,6 +9,10 @@ export const searchBook = (params: KAKAOParams) => {
 // "Content-Type": "application/json",
 // "Content-Type": "multipart/form-data"
 // "Authorization": "토큰"
+
+export const getMockData = (key: string, token?: string) => {
+  return mockClient(token).get(key);
+};
 
 export const getData = (key: string, token?: string) => {
   return client(token).get(key);

--- a/src/utils/lib/index.ts
+++ b/src/utils/lib/index.ts
@@ -27,3 +27,23 @@ export const client = (token?: string | null) => {
     headers,
   });
 };
+
+export const mockClient = (token?: string | null) => {
+  let headers;
+
+  if (token) {
+    headers = {
+      "Content-Type": "application/json",
+      Authorization: token,
+    };
+  } else {
+    headers = {
+      "Content-Type": "application/json",
+    };
+  }
+
+  return axios.create({
+    baseURL: `${process.env.REACT_APP_MOCK_URL}`,
+    headers,
+  });
+};


### PR DESCRIPTION
## 📌 내용
서재 독서 전,중,완료,모두 api를 모두 분리해봤습니다.
로딩 처리 구현 시, 몇몇 이슈가 있었는데 회의 때 이야기 하겠슴다.

<br />

## 📌 내가 알게 된 부분
postman으로 mock server 구현하는 법

<br />

## 📌 질문할 부분 
handlebookdelete를 pre,peri 등 각 페이지로 분리해줬는데 
bookcase 페이지에서 pathname(switch문)을 통해 한 번에 처리하여
outletcontext로 넘겨주는게 더 좋을지 고민