### PR TITLE
Feature nav shadow 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@types/react-dom": "^17.0.11",
     "@types/styled-components": "^5.1.19",
     "axios": "^0.24.0",
+    "framer-motion": "^6.2.3",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-router-dom": "^6.2.1",

--- a/src/components/addBook/AddBookDefault.tsx
+++ b/src/components/addBook/AddBookDefault.tsx
@@ -20,7 +20,7 @@ const StWrapper = styled.section`
   justify-content: center;
   align-items: center;
 
-  height: calc(100% - 23.8rem);
+  height: calc(100vh - 23.8rem);
 
   margin: 0 4rem 0 4rem;
 

--- a/src/components/addBook/BookEmpty.tsx
+++ b/src/components/addBook/BookEmpty.tsx
@@ -17,7 +17,7 @@ const StWrapper = styled.section`
   justify-content: center;
   align-items: center;
 
-  height: calc(100% - 23.8rem);
+  height: calc(100vh - 23.8rem);
 
   margin: 0 4rem 0 4rem;
 `;

--- a/src/components/addBook/SearchBar.tsx
+++ b/src/components/addBook/SearchBar.tsx
@@ -14,10 +14,17 @@ export default function SearchBar(props: SearchBarProps) {
   const shadowingAni = useAnimation();
   const { scrollY } = useViewportScroll();
 
-  // useEffect를 쓰는 것은 자유 (return 문에 조건문으로 끝내도 됨)
   useEffect(() => {
     scrollY.onChange(() => {
-      console.log(scrollY.get());
+      if (scrollY.get() > 109) {
+        shadowingAni.start({
+          boxShadow: "0rem 0.6rem 1rem rgba(0, 0, 0, 0.17)",
+        });
+      } else {
+        shadowingAni.start({
+          boxShadow: "initial",
+        });
+      }
     });
   }, [scrollY]);
 
@@ -32,7 +39,7 @@ export default function SearchBar(props: SearchBarProps) {
   };
 
   return (
-    <StWrapper>
+    <StWrapper animate={shadowingAni} initial={{ boxShadow: "initial" }}>
       <SearchBarWrapper isqueryempty={debounceQuery}>
         <StIcSearch isqueryempty={debounceQuery} />
 

--- a/src/components/addBook/SearchBar.tsx
+++ b/src/components/addBook/SearchBar.tsx
@@ -62,9 +62,10 @@ const StWrapper = styled(motion.section)`
   position: sticky;
   top: 0;
 
-  background-color: ${({ theme }) => theme.colors.white};
   padding-top: 3.1rem;
   padding-bottom: 3.5rem;
+
+  background-color: ${({ theme }) => theme.colors.white};
 `;
 
 const SearchBarWrapper = styled.div<{ isqueryempty: string }>`

--- a/src/components/addBook/SearchBar.tsx
+++ b/src/components/addBook/SearchBar.tsx
@@ -13,10 +13,11 @@ export default function SearchBar(props: SearchBarProps) {
   const { debounceQuery, onDebounceQuery } = props;
   const shadowingAni = useAnimation();
   const { scrollY } = useViewportScroll();
+  const MAIN_HEADER_HEIGHT = 109;
 
   useEffect(() => {
     scrollY.onChange(() => {
-      if (scrollY.get() > 109) {
+      if (scrollY.get() > MAIN_HEADER_HEIGHT) {
         shadowingAni.start({
           boxShadow: "0rem 0.6rem 1rem rgba(0, 0, 0, 0.17)",
         });

--- a/src/components/addBook/SearchBar.tsx
+++ b/src/components/addBook/SearchBar.tsx
@@ -1,3 +1,4 @@
+import { motion, useAnimation, useViewportScroll } from "framer-motion";
 import styled, { css } from "styled-components";
 
 import { IcCancel, IcSearch } from "../../assets/icons";

--- a/src/components/addBook/SearchBar.tsx
+++ b/src/components/addBook/SearchBar.tsx
@@ -1,4 +1,5 @@
 import { motion, useAnimation, useViewportScroll } from "framer-motion";
+import { useEffect } from "react";
 import styled, { css } from "styled-components";
 
 import { IcCancel, IcSearch } from "../../assets/icons";
@@ -10,6 +11,15 @@ interface SearchBarProps {
 }
 export default function SearchBar(props: SearchBarProps) {
   const { debounceQuery, onDebounceQuery } = props;
+  const shadowingAni = useAnimation();
+  const { scrollY } = useViewportScroll();
+
+  // useEffect를 쓰는 것은 자유 (return 문에 조건문으로 끝내도 됨)
+  useEffect(() => {
+    scrollY.onChange(() => {
+      console.log(scrollY.get());
+    });
+  }, [scrollY]);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const text = e.currentTarget.value;
@@ -40,7 +50,7 @@ export default function SearchBar(props: SearchBarProps) {
   );
 }
 
-const StWrapper = styled.section`
+const StWrapper = styled(motion.section)`
   position: sticky;
   top: 0;
 

--- a/src/components/bookcase/Cards.tsx
+++ b/src/components/bookcase/Cards.tsx
@@ -34,7 +34,7 @@ const StDefaultSection = styled.section`
   align-items: center;
   justify-content: center;
 
-  height: calc(100% - 19.7rem);
+  height: calc(100vh - 19.7rem);
 `;
 
 const StSection = styled.section`

--- a/src/components/bookcase/Navigation.tsx
+++ b/src/components/bookcase/Navigation.tsx
@@ -1,10 +1,28 @@
+import { motion, useAnimation, useViewportScroll } from "framer-motion";
 import { useEffect, useState } from "react";
 import { Link, useLocation } from "react-router-dom";
 import styled from "styled-components";
 
 export default function Navigation() {
-  const location = useLocation();
   const [navIndex, setNavIndex] = useState<number>(0);
+  const location = useLocation();
+  const shadowingAni = useAnimation();
+  const { scrollY } = useViewportScroll();
+  const MAIN_HEADER_HEIGHT = 109;
+
+  useEffect(() => {
+    scrollY.onChange(() => {
+      if (scrollY.get() > MAIN_HEADER_HEIGHT) {
+        shadowingAni.start({
+          boxShadow: "0rem 0.6rem 1rem rgba(0, 0, 0, 0.17)",
+        });
+      } else {
+        shadowingAni.start({
+          boxShadow: "initial",
+        });
+      }
+    });
+  }, [scrollY]);
 
   useEffect(() => {
     switch (location.pathname) {
@@ -24,7 +42,7 @@ export default function Navigation() {
   }, [location.pathname]);
 
   return (
-    <StNav>
+    <StNav animate={shadowingAni} initial={{ boxShadow: "initial" }}>
       <StUl>
         <StList>
           <StLink to="/main/bookcase">전체</StLink>
@@ -46,7 +64,7 @@ export default function Navigation() {
   );
 }
 
-const StNav = styled.nav`
+const StNav = styled(motion.nav)`
   position: sticky;
   top: 0;
 
@@ -56,8 +74,6 @@ const StNav = styled.nav`
   padding-left: 4rem;
 
   background-color: ${({ theme }) => theme.colors.white};
-
-  width: 100%;
 `;
 
 const StUl = styled.ul`

--- a/src/components/common/CommonLayout.tsx
+++ b/src/components/common/CommonLayout.tsx
@@ -17,5 +17,5 @@ export default function CommonLayout() {
 const StWrapper = styled.section`
   display: flex;
   background-color: ${({ theme }) => theme.colors.gray100};
-  height: 100vh;
+  min-height: 100vh;
 `;

--- a/src/components/common/CommonLayout.tsx
+++ b/src/components/common/CommonLayout.tsx
@@ -15,7 +15,5 @@ export default function CommonLayout() {
 }
 
 const StWrapper = styled.section`
-  display: flex;
   background-color: ${({ theme }) => theme.colors.gray100};
-  min-height: 100vh;
 `;

--- a/src/components/common/MainLayout.tsx
+++ b/src/components/common/MainLayout.tsx
@@ -9,13 +9,12 @@ export default function MainLayout({ children }: MainLayoutProps) {
 }
 
 const StWrapper = styled.main`
+  position: relative;
+  min-height: 100vh;
+
   margin-left: 17.5rem;
 
-  position: relative;
-  flex: 1;
   border-radius: 2rem 0 0 2rem;
   border: 0.1rem solid ${({ theme }) => theme.colors.white};
   background-color: ${({ theme }) => theme.colors.white};
-
-  overflow-y: auto;
 `;

--- a/src/components/common/MainLayout.tsx
+++ b/src/components/common/MainLayout.tsx
@@ -10,6 +10,7 @@ export default function MainLayout({ children }: MainLayoutProps) {
 
 const StWrapper = styled.main`
   position: relative;
+  width: calc(100vw - 17.5rem);
   min-height: 100vh;
 
   margin-left: 17.5rem;

--- a/src/components/common/MainLayout.tsx
+++ b/src/components/common/MainLayout.tsx
@@ -9,12 +9,13 @@ export default function MainLayout({ children }: MainLayoutProps) {
 }
 
 const StWrapper = styled.main`
+  margin-left: 17.5rem;
+
   position: relative;
   flex: 1;
   border-radius: 2rem 0 0 2rem;
   border: 0.1rem solid ${({ theme }) => theme.colors.white};
   background-color: ${({ theme }) => theme.colors.white};
 
-  font-family: pretendard;
   overflow-y: auto;
 `;

--- a/src/components/common/MainLayout.tsx
+++ b/src/components/common/MainLayout.tsx
@@ -10,7 +10,7 @@ export default function MainLayout({ children }: MainLayoutProps) {
 
 const StWrapper = styled.main`
   position: relative;
-  width: calc(100vw - 17.5rem);
+  width: calc(100% - 17.5rem);
   min-height: 100vh;
 
   margin-left: 17.5rem;

--- a/src/components/common/NavWrapper.tsx
+++ b/src/components/common/NavWrapper.tsx
@@ -57,19 +57,23 @@ export default function NavWrapper() {
 }
 
 const StSection = styled.section`
-  position: relative;
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+
   background-color: ${({ theme }) => theme.colors.gray100};
   width: 17.5rem;
   color: ${({ theme }) => theme.colors.white500};
+
+  z-index: 10;
 `;
 
 const StNav = styled.nav`
-  position: absolute;
   margin-top: 12.3rem;
   padding-left: 2.2rem;
-  font-size: 1.6rem;
-  font-weight: bold;
-  line-height: 1.9rem;
+
+  ${({ theme }) => theme.fonts.body5}
 `;
 
 const StUl = styled.ul`
@@ -99,5 +103,6 @@ const StItem = styled.li<{ color: string }>`
 const StLink = styled(Link)`
   display: flex;
   align-items: center;
+
   ${({ theme }) => theme.fonts.body5};
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1065,7 +1065,7 @@
   resolved "https://registry.yarnpkg.com/@csstools/normalize.css/-/normalize.css-12.0.0.tgz#a9583a75c3f150667771f30b60d9f059473e62c4"
   integrity sha512-M0qqxAcwCsIVfpFQSlGN5XjXWu8l5JDZN+fPt1LeW5SZexQTgnaEvgXAY+CeygRw0EeppWHi12JxESWiWrB0Sg==
 
-"@emotion/is-prop-valid@^0.8.8":
+"@emotion/is-prop-valid@^0.8.2", "@emotion/is-prop-valid@^0.8.8":
   version "0.8.8"
   resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz#db28b1c4368a259b60a97311d6a952d4fd01ac1a"
   integrity sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==
@@ -4331,6 +4331,26 @@ fraction.js@^4.1.2:
   resolved "https://registry.yarnpkg.com/fraction.js/-/fraction.js-4.1.2.tgz#13e420a92422b6cf244dff8690ed89401029fbe8"
   integrity sha512-o2RiJQ6DZaR/5+Si0qJUIy637QMRudSi9kU/FFzx9EZazrIdnBgpU+3sEWCxAVhH2RtxW2Oz+T4p2o8uOPVcgA==
 
+framer-motion@^6.2.3:
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/framer-motion/-/framer-motion-6.2.3.tgz#1ff314c178566a286d2b985fd31cab3910cf1eed"
+  integrity sha512-2afb2KvqFi5bEgyKEVNm/RGvMThHbWvHPvdJMmm9DR+Lg2tvCmc9o459gQ20tNxLoRUmCGF8bKtm9lvPlqxh2Q==
+  dependencies:
+    framesync "6.0.1"
+    hey-listen "^1.0.8"
+    popmotion "11.0.3"
+    style-value-types "5.0.0"
+    tslib "^2.1.0"
+  optionalDependencies:
+    "@emotion/is-prop-valid" "^0.8.2"
+
+framesync@6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/framesync/-/framesync-6.0.1.tgz#5e32fc01f1c42b39c654c35b16440e07a25d6f20"
+  integrity sha512-fUY88kXvGiIItgNC7wcTOl0SNRCVXMKSWW2Yzfmn7EKNc+MpCzcz9DhdHcdjbrtN3c6R4H5dTY2jiCpPdysEjA==
+  dependencies:
+    tslib "^2.1.0"
+
 fresh@0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
@@ -4553,6 +4573,11 @@ he@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
+hey-listen@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/hey-listen/-/hey-listen-1.0.8.tgz#8e59561ff724908de1aa924ed6ecc84a56a9aa68"
+  integrity sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==
 
 history@^5.2.0:
   version "5.2.0"
@@ -6435,6 +6460,16 @@ pkg-up@^3.1.0:
   dependencies:
     find-up "^3.0.0"
 
+popmotion@11.0.3:
+  version "11.0.3"
+  resolved "https://registry.yarnpkg.com/popmotion/-/popmotion-11.0.3.tgz#565c5f6590bbcddab7a33a074bb2ba97e24b0cc9"
+  integrity sha512-Y55FLdj3UxkR7Vl3s7Qr4e9m0onSnP8W7d/xQLsoJM40vs6UKHFdygs6SWryasTZYqugMjm3BepCF4CWXDiHgA==
+  dependencies:
+    framesync "6.0.1"
+    hey-listen "^1.0.8"
+    style-value-types "5.0.0"
+    tslib "^2.1.0"
+
 portfinder@^1.0.28:
   version "1.0.28"
   resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.28.tgz#67c4622852bd5374dd1dd900f779f53462fac778"
@@ -8034,6 +8069,14 @@ style-loader@^3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-3.3.1.tgz#057dfa6b3d4d7c7064462830f9113ed417d38575"
   integrity sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ==
+
+style-value-types@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/style-value-types/-/style-value-types-5.0.0.tgz#76c35f0e579843d523187989da866729411fc8ad"
+  integrity sha512-08yq36Ikn4kx4YU6RD7jWEv27v4V+PUsOGa4n/as8Et3CuODMJQ00ENeAVXAeydX4Z2j1XHZF1K2sX4mGl18fA==
+  dependencies:
+    hey-listen "^1.0.8"
+    tslib "^2.1.0"
 
 styled-components@^5.3.3:
   version "5.3.3"


### PR DESCRIPTION
## 📌 내용
<!-- 하고 싶은 말 자유롭게 -->
- 라이브러리 사용하여 스크롤 시 박스 그림자 구현 완료
![image](https://user-images.githubusercontent.com/47105088/152336006-a3d5bc47-6568-49f2-a523-3601e388d989.png)
- 서재 뷰에서 nav의 `padding-bottom` 부분은 건드리지 않은 채로 그냥 피그마의 뷰대로 구현하였습니다,
디쟌팀에서의 요구사항을 정확히 아시는 분은 추후에 수정해주세용

<br />

## 📌 내가 알게 된 부분
<!-- 새롭게 알게 된 부분을 적쟈 (기록하면서 개발하기!) -->
- `frame-motion` 라이브러리 사용법 (내일 이것만 볼 예정)

<br />

## 📌 질문할 부분 
<!-- 작은 거라도 조아  -->
- 스크롤 정보를 계속 불러오기 위해, `main layout` css 를 다소 수정했습니다
즉, `100vh`의 높이를 수정했고, 다음과 같은 이슈가 발생하였습니다

https://user-images.githubusercontent.com/47105088/152339082-e620e837-fbd3-43ae-8e95-63235979b661.mp4


![image](https://user-images.githubusercontent.com/47105088/152336502-5b3b98cc-da3e-426b-bb48-4c9212bcf0e5.png)
`main section`의 길이가 늘어나게 되면, `border-radius`를 유지하면서 스크롤 할 수 없습니다
이를 해결하기 위해서는
1. `nav section` 에서 오른쪽의 `border-radius` 를 처리하거나
2. `main section` 에서 `100vh` 높이를 유지하면서 스크롤 정보를 가져오는 방법을 찾거나

해야 할 것 같은데 생각나시는 방법이 있을까용
