### PR TITLE
fix: 엔터로 꼬리질문 추가 시 depth가 이상한 문제

### DIFF
--- a/src/components/bookNote/periNote/PeriNote.tsx
+++ b/src/components/bookNote/periNote/PeriNote.tsx
@@ -62,7 +62,8 @@ export default function PeriNote() {
 
     if (isQuestion) {
       // 꼬리 질문 추가 시에는 답변이 함께 생성되어야 함
-      current.children.splice(currentIndex + 1, 0, {
+      // 꼬리 질문은 무조건 마지막에 추가되면 됨
+      current.children.push({
         type: "question",
         content: "",
         children: [

--- a/src/components/bookNote/periNote/PeriNote.tsx
+++ b/src/components/bookNote/periNote/PeriNote.tsx
@@ -55,14 +55,15 @@ export default function PeriNote() {
   const [openModal, setOpenModal] = useState<boolean>(false);
   const [openSubmitModal, setOpenSubmitModal] = useState<boolean>(false);
 
-  const handleAddChild = (path: number[], isQuestion: boolean) => {
+  const handleAddChild = (path: number[], currentIndex: number, isQuestion: boolean) => {
     // 깊은 복사 후 위치를 찾아 새로운 node를 추가하고 root를 set에 넘김
     const newRoot = deepCopyTree(data.answerThree);
     const current = getNodeByPath(newRoot, path);
 
+    console.log("current.children", current.children);
     if (isQuestion) {
       // 꼬리 질문 추가 시에는 답변이 함께 생성되어야 함
-      current.children.push({
+      current.children.splice(currentIndex + 1, 0, {
         type: "question",
         content: "",
         children: [
@@ -74,7 +75,7 @@ export default function PeriNote() {
         ],
       });
     } else {
-      current.children.push({
+      current.children.splice(currentIndex + 1, 0, {
         type: "answer",
         content: "",
         children: [],
@@ -188,6 +189,7 @@ export default function PeriNote() {
               <StArticle key={`input-${idx}`}>
                 <PriorQuestion
                   path={[idx]}
+                  index={idx}
                   node={node}
                   onAddChild={handleAddChild}
                   onSetContent={handleSetContent}
@@ -195,7 +197,10 @@ export default function PeriNote() {
                 />
               </StArticle>
             ))}
-          <StAddChildButton type="button" disabled={isPrevented} onClick={() => handleAddChild([], true)}>
+          <StAddChildButton
+            type="button"
+            disabled={isPrevented}
+            onClick={() => handleAddChild([], data.answerThree.children.length, true)}>
             질문 리스트 추가
           </StAddChildButton>
           {/* 북노트 정리되면 type submit으로 바꾸기 */}

--- a/src/components/bookNote/periNote/PeriNote.tsx
+++ b/src/components/bookNote/periNote/PeriNote.tsx
@@ -60,7 +60,6 @@ export default function PeriNote() {
     const newRoot = deepCopyTree(data.answerThree);
     const current = getNodeByPath(newRoot, path);
 
-    console.log("current.children", current.children);
     if (isQuestion) {
       // 꼬리 질문 추가 시에는 답변이 함께 생성되어야 함
       current.children.splice(currentIndex + 1, 0, {
@@ -85,7 +84,7 @@ export default function PeriNote() {
     setData({ ...data, answerThree: newRoot });
   };
 
-  const handleSetContent = (path: number[], value: string) => {
+  const handleSetContent = (value: string, path: number[]) => {
     const newRoot = deepCopyTree(data.answerThree);
     const current = getNodeByPath(newRoot, path);
 

--- a/src/components/bookNote/periNote/PeriNoteInput.tsx
+++ b/src/components/bookNote/periNote/PeriNoteInput.tsx
@@ -11,7 +11,7 @@ interface PeriNoteInputProps {
   index: number;
   node: PeriNoteTreeNode;
   onAddChild: (path: number[], index: number, isQuestion: boolean) => void;
-  onSetContent: (path: number[], value: string) => void;
+  onSetContent: (value: string, path: number[]) => void;
   onDeleteChild: (path: number[]) => void;
   onAddChildByEnter: (
     e: React.KeyboardEvent<HTMLTextAreaElement>,
@@ -45,6 +45,7 @@ export default function PeriNoteInput(props: PeriNoteInputProps) {
 
   useEffect(() => {
     if (textAreaRef.current) {
+      textAreaRef.current.value = "";
       textAreaRef.current.focus();
     }
   }, []);
@@ -63,7 +64,7 @@ export default function PeriNoteInput(props: PeriNoteInputProps) {
             ref={textAreaRef}
             value={node.content}
             placeholder={`${isQuestion ? "질문" : "답변"}을 입력해주세요.`}
-            onChange={(e) => onSetContent(path, e.target.value)}
+            onChange={(e) => onSetContent(e.target.value, path)}
             onKeyPress={(e) => onAddChildByEnter(e, path.slice(0, -1), index, isQuestion)}
           />
           {isQuestion && (
@@ -93,7 +94,7 @@ export default function PeriNoteInput(props: PeriNoteInputProps) {
               index={i}
               node={node}
               onAddChild={(p, i, isQ) => onAddChild(p, i, isQ)}
-              onSetContent={(p, value) => onSetContent(p, value)}
+              onSetContent={(v, p) => onSetContent(v, p)}
               onDeleteChild={(p) => onDeleteChild(p)}
               onAddChildByEnter={(e, p, i, isQ) => onAddChildByEnter(e, p, i, isQ)}
             />

--- a/src/components/bookNote/periNote/PeriNoteInput.tsx
+++ b/src/components/bookNote/periNote/PeriNoteInput.tsx
@@ -38,14 +38,18 @@ export default function PeriNoteInput(props: PeriNoteInputProps) {
   const { path, index, node, onAddChild, onSetContent, onDeleteChild, onAddChildByEnter } = props;
   const isQuestion = node.type === "question";
 
-  // 4depth로 제한하기 전이라서 순환하도록 했음 -> 제한을 두면 % 8 지우기
-  // 첫 시작 root 때문에 1을 빼야 함
   const labelColor = labelColorList[(path.length - 1) % 10];
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
 
+  const addChildByEnter = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      // 꼬리질문과 답변은 자신의 아래에 추가하는 것이 아닌 자신의 부모의 children에 추가해야함
+      onAddChild(path.slice(0, -1), index, isQuestion);
+    }
+  };
+
   useEffect(() => {
     if (textAreaRef.current) {
-      textAreaRef.current.value = "";
       textAreaRef.current.focus();
     }
   }, []);
@@ -65,7 +69,7 @@ export default function PeriNoteInput(props: PeriNoteInputProps) {
             value={node.content}
             placeholder={`${isQuestion ? "질문" : "답변"}을 입력해주세요.`}
             onChange={(e) => onSetContent(e.target.value, path)}
-            onKeyPress={(e) => onAddChildByEnter(e, path.slice(0, -1), index, isQuestion)}
+            onKeyPress={addChildByEnter}
           />
           {isQuestion && (
             <StAddAnswerButton type="button" onClick={() => onAddChild(path, index, !isQuestion)}>

--- a/src/components/bookNote/periNote/PeriNoteInput.tsx
+++ b/src/components/bookNote/periNote/PeriNoteInput.tsx
@@ -8,16 +8,17 @@ import { StAddAnswerButton, StMenu, StMenuBtn, StMoreIcon } from "./PriorQuestio
 
 interface PeriNoteInputProps {
   path: number[];
+  index: number;
   node: PeriNoteTreeNode;
-  onAddChild: (path: number[], isQuestion: boolean) => void;
+  onAddChild: (path: number[], index: number, isQuestion: boolean) => void;
   onSetContent: (path: number[], value: string) => void;
   onDeleteChild: (path: number[]) => void;
-  onAddQuestion: (
-    e: React.MouseEvent<HTMLButtonElement, MouseEvent>,
+  onAddChildByEnter: (
+    e: React.KeyboardEvent<HTMLTextAreaElement>,
     pathArray: number[],
-    isQuestionChecked: boolean,
+    index: number,
+    isQuestion: boolean,
   ) => void;
-  onAddChildByEnter: (e: React.KeyboardEvent<HTMLTextAreaElement>, pathArray: number[], isQuestion: boolean) => void;
 }
 
 export const labelColorList = [
@@ -34,7 +35,7 @@ export const labelColorList = [
 ];
 
 export default function PeriNoteInput(props: PeriNoteInputProps) {
-  const { path, node, onAddChild, onSetContent, onDeleteChild, onAddQuestion, onAddChildByEnter } = props;
+  const { path, index, node, onAddChild, onSetContent, onDeleteChild, onAddChildByEnter } = props;
   const isQuestion = node.type === "question";
 
   // 4depth로 제한하기 전이라서 순환하도록 했음 -> 제한을 두면 % 8 지우기
@@ -63,17 +64,17 @@ export default function PeriNoteInput(props: PeriNoteInputProps) {
             value={node.content}
             placeholder={`${isQuestion ? "질문" : "답변"}을 입력해주세요.`}
             onChange={(e) => onSetContent(path, e.target.value)}
-            onKeyPress={(e) => onAddChildByEnter(e, path, isQuestion)}
+            onKeyPress={(e) => onAddChildByEnter(e, path.slice(0, -1), index, isQuestion)}
           />
           {isQuestion && (
-            <StAddAnswerButton type="button" onClick={() => onAddChild(path, !isQuestion)}>
+            <StAddAnswerButton type="button" onClick={() => onAddChild(path, index, !isQuestion)}>
               답변
             </StAddAnswerButton>
           )}
           <StMore className="icn_more" />
           <StMenu>
             {!isQuestion && (
-              <StMenuBtn type="button" onClick={(e) => onAddQuestion(e, path, !isQuestion)}>
+              <StMenuBtn type="button" onClick={() => onAddChild(path, index, !isQuestion)}>
                 꼬리질문 추가
               </StMenuBtn>
             )}
@@ -89,12 +90,12 @@ export default function PeriNoteInput(props: PeriNoteInputProps) {
             <PeriNoteInput
               key={`input-${i}`}
               path={[...path, i]}
+              index={i}
               node={node}
-              onAddChild={(p, isQ) => onAddChild(p, isQ)}
+              onAddChild={(p, i, isQ) => onAddChild(p, i, isQ)}
               onSetContent={(p, value) => onSetContent(p, value)}
               onDeleteChild={(p) => onDeleteChild(p)}
-              onAddQuestion={(e, p, isQ) => onAddQuestion(e, p, isQ)}
-              onAddChildByEnter={(e, p, isQ) => onAddChildByEnter(e, p, isQ)}
+              onAddChildByEnter={(e, p, i, isQ) => onAddChildByEnter(e, p, i, isQ)}
             />
           ))}
       </StFieldWrapper>

--- a/src/components/bookNote/periNote/PriorAnswer.tsx
+++ b/src/components/bookNote/periNote/PriorAnswer.tsx
@@ -9,20 +9,21 @@ import { StMenu, StMenuBtn, StMoreIcon } from "./PriorQuestion";
 
 interface PriorAnswerProps {
   path: number[];
+  index: number;
   node: PeriNoteTreeNode;
-  onAddChild: (path: number[], isQuestion: boolean) => void;
+  onAddChild: (path: number[], index: number, isQuestion: boolean) => void;
   onSetContent: (path: number[], value: string) => void;
   onDeleteChild: (path: number[]) => void;
 }
 
 export default function PriorAnswer(props: PriorAnswerProps) {
-  const { path, node, onAddChild, onSetContent, onDeleteChild } = props;
+  const { path, index, node, onAddChild, onSetContent, onDeleteChild } = props;
   const isQuestion = false;
 
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
 
-  const handleClickAddChild = (pathArray: number[], isQuestionChecked: boolean) => {
-    onAddChild(pathArray, isQuestionChecked);
+  const handleClickAddChild = (pathArray: number[], idx: number, isQuestionChecked: boolean) => {
+    onAddChild(pathArray, idx, isQuestionChecked);
   };
 
   const handleChangeSetContent = (pathArray: number[], value: string) => {
@@ -35,24 +36,17 @@ export default function PriorAnswer(props: PriorAnswerProps) {
     onDeleteChild(pathArray);
   };
 
-  const handleClickAddQuestion = (
-    e: React.MouseEvent<HTMLButtonElement, MouseEvent>,
-    pathArray: number[],
-    isQuestionChecked: boolean,
-  ) => {
-    handleClickAddChild(pathArray, isQuestionChecked);
-  };
-
   const handleKeyPress = (
     e: React.KeyboardEvent<HTMLTextAreaElement>,
     pathArray: number[],
+    idx: number,
     isQuestionChecked: boolean,
   ) => {
     if (e.key === "Enter") {
       if (!e.shiftKey) {
         const p = isQuestionChecked ? pathArray : pathArray.slice(0, -1);
 
-        handleClickAddChild(p, isQuestionChecked);
+        onAddChild(p, idx, isQuestionChecked);
       }
     }
   };
@@ -74,11 +68,11 @@ export default function PriorAnswer(props: PriorAnswerProps) {
           value={node.content}
           placeholder={"답변을 입력해주세요."}
           onChange={(e) => handleChangeSetContent(path, e.target.value)}
-          onKeyPress={(e) => handleKeyPress(e, path, isQuestion)}
+          onKeyPress={(e) => handleKeyPress(e, path, index, isQuestion)}
         />
         <StMore className="icn_more" />
         <StMenu menuposition={"isPriQ"}>
-          <StMenuBtn type="button" onClick={(e) => handleClickAddQuestion(e, path, !isQuestion)}>
+          <StMenuBtn type="button" onClick={() => handleClickAddChild(path, index, !isQuestion)}>
             꼬리질문 추가
           </StMenuBtn>
           <StMenuBtn type="button" onClick={() => handleClickDeleteChild(path)}>
@@ -91,12 +85,12 @@ export default function PriorAnswer(props: PriorAnswerProps) {
           <PeriNoteInput
             key={`input-${i}`}
             path={[...path, i]}
+            index={i}
             node={node}
-            onAddChild={(p, isQ) => handleClickAddChild(p, isQ)}
+            onAddChild={(p, i, isQ) => handleClickAddChild(p, i, isQ)}
             onSetContent={(p, value) => handleChangeSetContent(p, value)}
             onDeleteChild={(p) => onDeleteChild(p)}
-            onAddQuestion={(e, p, isQ) => handleClickAddQuestion(e, p, isQ)}
-            onAddChildByEnter={(e, p, isQ) => handleKeyPress(e, p, isQ)}
+            onAddChildByEnter={(e, p, i, isQ) => handleKeyPress(e, p, i, isQ)}
           />
         ))}
     </StFieldset>

--- a/src/components/bookNote/periNote/PriorAnswer.tsx
+++ b/src/components/bookNote/periNote/PriorAnswer.tsx
@@ -12,7 +12,7 @@ interface PriorAnswerProps {
   index: number;
   node: PeriNoteTreeNode;
   onAddChild: (path: number[], index: number, isQuestion: boolean) => void;
-  onSetContent: (path: number[], value: string) => void;
+  onSetContent: (value: string, path: number[]) => void;
   onDeleteChild: (path: number[]) => void;
 }
 
@@ -26,9 +26,9 @@ export default function PriorAnswer(props: PriorAnswerProps) {
     onAddChild(pathArray, idx, isQuestionChecked);
   };
 
-  const handleChangeSetContent = (pathArray: number[], value: string) => {
-    if (value !== "\n") {
-      onSetContent(pathArray, value);
+  const handleChangeSetContent = (e: React.ChangeEvent<HTMLTextAreaElement>, pathArray: number[]) => {
+    if (e.target.value !== "\n") {
+      onSetContent(e.target.value, pathArray);
     }
   };
 
@@ -53,6 +53,7 @@ export default function PriorAnswer(props: PriorAnswerProps) {
 
   useEffect(() => {
     if (textAreaRef.current) {
+      textAreaRef.current.value = "";
       textAreaRef.current.focus();
     }
   }, []);
@@ -67,7 +68,7 @@ export default function PriorAnswer(props: PriorAnswerProps) {
           ref={textAreaRef}
           value={node.content}
           placeholder={"답변을 입력해주세요."}
-          onChange={(e) => handleChangeSetContent(path, e.target.value)}
+          onChange={(e) => handleChangeSetContent(e, path)}
           onKeyPress={(e) => handleKeyPress(e, path, index, isQuestion)}
         />
         <StMore className="icn_more" />
@@ -88,7 +89,7 @@ export default function PriorAnswer(props: PriorAnswerProps) {
             index={i}
             node={node}
             onAddChild={(p, i, isQ) => handleClickAddChild(p, i, isQ)}
-            onSetContent={(p, value) => handleChangeSetContent(p, value)}
+            onSetContent={(v, p) => onSetContent(v, p)}
             onDeleteChild={(p) => onDeleteChild(p)}
             onAddChildByEnter={(e, p, i, isQ) => handleKeyPress(e, p, i, isQ)}
           />

--- a/src/components/bookNote/periNote/PriorQuestion.tsx
+++ b/src/components/bookNote/periNote/PriorQuestion.tsx
@@ -12,7 +12,7 @@ interface PriorQuestionProps {
   index: number;
   node: PeriNoteTreeNode;
   onAddChild: (path: number[], currentIndex: number, isQuestion: boolean) => void;
-  onSetContent: (path: number[], value: string) => void;
+  onSetContent: (value: string, path: number[]) => void;
   onDeleteChild: (path: number[]) => void;
 }
 
@@ -23,16 +23,16 @@ export default function PriorQuestion(props: PriorQuestionProps) {
 
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
 
-  const handleContent = (pathArray: number[], value: string) => {
-    if (value !== "\n") {
-      onSetContent(pathArray, value);
+  const handleContent = (e: React.ChangeEvent<HTMLTextAreaElement>, pathArray: number[]) => {
+    if (e.target.value !== "\n") {
+      onSetContent(e.target.value, pathArray);
     }
   };
 
   const handleKeyPress = (e: React.KeyboardEvent<HTMLTextAreaElement>, pathArray: number[]) => {
-    if (e.key === "Enter") {
+    if (e.key === "Enter" && !e.shiftKey) {
       if (!e.shiftKey) {
-        onAddChild(pathArray, index, isQuestion);
+        onAddChild(pathArray, node.children.length - 1, isQuestion);
       }
     }
   };
@@ -53,7 +53,7 @@ export default function PriorQuestion(props: PriorQuestionProps) {
           ref={textAreaRef}
           value={node.content}
           placeholder={"질문을 입력해주세요."}
-          onChange={(e) => handleContent(path, e.target.value)}
+          onChange={(e) => handleContent(e, path)}
           onKeyPress={(e) => handleKeyPress(e, path)}
         />
         <StAddAnswerButton type="button" onClick={() => onAddChild(path, index, isQuestion)}>
@@ -74,7 +74,7 @@ export default function PriorQuestion(props: PriorQuestionProps) {
             index={i}
             node={node}
             onAddChild={(p, i, isQ) => onAddChild(p, i, isQ)}
-            onSetContent={(p, value) => onSetContent(p, value)}
+            onSetContent={(v, p) => onSetContent(v, p)}
             onDeleteChild={(p) => onDeleteChild(p)}
           />
         ))}

--- a/src/components/bookNote/periNote/PriorQuestion.tsx
+++ b/src/components/bookNote/periNote/PriorQuestion.tsx
@@ -9,14 +9,16 @@ import { PriorAnswer } from "..";
 
 interface PriorQuestionProps {
   path: number[];
+  index: number;
   node: PeriNoteTreeNode;
-  onAddChild: (path: number[], isQuestion: boolean) => void;
+  onAddChild: (path: number[], currentIndex: number, isQuestion: boolean) => void;
   onSetContent: (path: number[], value: string) => void;
   onDeleteChild: (path: number[]) => void;
 }
 
 export default function PriorQuestion(props: PriorQuestionProps) {
-  const { path, node, onAddChild, onSetContent, onDeleteChild } = props;
+  const { path, index, node, onAddChild, onSetContent, onDeleteChild } = props;
+  // 답변 추가 시 사용되는 변수라서 isQuestion false인 것
   const isQuestion = false;
 
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
@@ -30,7 +32,7 @@ export default function PriorQuestion(props: PriorQuestionProps) {
   const handleKeyPress = (e: React.KeyboardEvent<HTMLTextAreaElement>, pathArray: number[]) => {
     if (e.key === "Enter") {
       if (!e.shiftKey) {
-        onAddChild(pathArray, isQuestion);
+        onAddChild(pathArray, index, isQuestion);
       }
     }
   };
@@ -54,7 +56,7 @@ export default function PriorQuestion(props: PriorQuestionProps) {
           onChange={(e) => handleContent(path, e.target.value)}
           onKeyPress={(e) => handleKeyPress(e, path)}
         />
-        <StAddAnswerButton type="button" onClick={() => onAddChild(path, isQuestion)}>
+        <StAddAnswerButton type="button" onClick={() => onAddChild(path, index, isQuestion)}>
           답변
         </StAddAnswerButton>
         <StMoreIcon className="icn_more" />
@@ -69,8 +71,9 @@ export default function PriorQuestion(props: PriorQuestionProps) {
           <PriorAnswer
             key={i}
             path={[...path, i]}
+            index={i}
             node={node}
-            onAddChild={(p, isQ) => onAddChild(p, isQ)}
+            onAddChild={(p, i, isQ) => onAddChild(p, i, isQ)}
             onSetContent={(p, value) => onSetContent(p, value)}
             onDeleteChild={(p) => onDeleteChild(p)}
           />


### PR DESCRIPTION
## 📌 내용
<!-- 하고 싶은 말 자유롭게 -->
- 엔터를 눌렀을 때 질문/답변이 추가되는 로직을 검수 중입니다.
- autoFocus 등의 문제가 조금 있네유,,

- [x] 엔터 입력시 전달되는 path의 수정이 필요
  - [x] 질문리스트 추가 시에는 root의 children의 마지막에 question과 answer를 추가
  - [x] 큰 질문에서의 엔터는 자신의 children의 마지막에 answer를 추가
  - [x] 큰 답변에서의 엔터는 자신 index의 다음에 answer를 추가
  - [x] 꼬리 질문에서의 엔터는 자신의 부모의 children의 마지막에 question과 answer를 추가
  - [x] 꼬리 답변에서의 엔터는 자신 index의 다음에 answer를 추가

<br />

## 📌 내가 알게 된 부분
<!-- 새롭게 알게 된 부분을 적쟈 (기록하면서 개발하기!) -->
- 처음부터 꼼꼼하게 한 번 두 번 세 번 백 번 확인하기

<br />

## 📌 질문할 부분 
<!-- 작은 거라도 조아  -->
- autoFocus가 진짜 감이 안잡혀