### PR TITLE
fix: 독서 전-중 질문 리스트 동기화 버그

### DIFF
--- a/src/components/bookNote/preNote/PreNote.tsx
+++ b/src/components/bookNote/preNote/PreNote.tsx
@@ -53,6 +53,7 @@ export default function PreNote() {
   const [isFilledOnlyThree, setIsFilledOnlyThree] = useState<boolean>(false);
   const [openModal, setOpenModal] = useState<boolean>(false);
 
+  const [ableGoPeri, setAbleGoPeri] = useState<boolean>(true);
   const isLogin = useRecoilValue(isLoginState);
   const navigate = useNavigate();
 
@@ -70,6 +71,8 @@ export default function PreNote() {
 
   // 독서 중으로 넘어가기 - 모달 내 '다음' 버튼 - 수정 완료
   const handleSubmit = async () => {
+    setAbleGoPeri(true);
+
     if (!data.finishSt) {
       patchBookNote(userToken, `/review/${reviewId}/pre`, { ...data, reviewSt: 3 });
     } else {
@@ -83,7 +86,8 @@ export default function PreNote() {
         questionFromPre.push({ type: "question", content, children: [{ type: "answer", content: "", children: [] }] });
       });
 
-      patchBookNote(userToken, `review/${reviewId}/peri`, {
+      setAbleGoPeri(false);
+      const resData = await patchBookNote(userToken, `review/${reviewId}/peri`, {
         answerThree: {
           type: "Root",
           content: "root",
@@ -92,13 +96,17 @@ export default function PreNote() {
         reviewSt: 3,
         finishSt: false,
       });
+
+      if (resData) {
+        setAbleGoPeri(true);
+      }
     }
 
     // call stack이 비워질 때 바로 실행할 수 있도록
     setTimeout(() => {
       handlePrevent(false);
       setOpenModal(false);
-      navigate("/book-note/peri");
+      if (ableGoPeri) navigate("/book-note/peri");
     }, 0);
   };
 


### PR DESCRIPTION
## 📌 내용
<!-- 하고 싶은 말 자유롭게 -->
- 될지 안될지는 디버깅도 불가능해서 일단 때려박음..
- 제대로 patch가 끝나기 전에 periNote로 이동하는 것이 핵심 문제인 것 같음
  왜? 문제가 되는 질문 빈 칸 하나만 있는 모습은 클라에서 설정한 초기값이 아니라 서버에서의 초기값이 넘어오는 것. 또한, 나갔다 들어오면 제대로 patch된 데이터가 남아있음.
- useSWR과 mutate를 사용한다면 더욱 깔끔하고 스무th하겠다는 생각도 듦. 근데 당장 시간이 부족하고 디버깅 자체가 안되니까 고민하다가 그냥 쉬운 방법을 싸질러봄. 오전 중에 다시 해보게씀

<br />

## 📌 내가 알게 된 부분
<!-- 새롭게 알게 된 부분을 적쟈 (기록하면서 개발하기!) -->
- 

<br />

## 📌 질문할 부분 
<!-- 작은 거라도 조아  -->
- 