### PR TITLE
1차 릴리즈 버그 수정: 비밀번호 패턴 Regex 변경

### DIFF
--- a/src/utils/check.ts
+++ b/src/utils/check.ts
@@ -24,7 +24,8 @@ export function checkNicknameType(value: string) {
   }
 }
 export function checkPwdType(value: string) {
-  const passwordRegex = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&-])[A-Za-z\d@$!%*#?&-]{8,64}$/;
+  const passwordRegex =
+    /^(?=.*[A-Za-z])(?=.*\d)(?=.*[!#$%&*+,-./:;<=>?@^_|~(){}[\]])[A-Za-z\d!#$%&*+,-./:;<=>?@^_|~(){}[\]]{8,64}$/;
 
   return passwordRegex.test(value);
 }

--- a/src/utils/check.ts
+++ b/src/utils/check.ts
@@ -24,7 +24,7 @@ export function checkNicknameType(value: string) {
   }
 }
 export function checkPwdType(value: string) {
-  const passwordRegex = /^(?=.*[a-zA-Z])((?=.*\d)(?=.*[!@#$%^&*-~])).{8,64}$/;
+  const passwordRegex = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&-])[A-Za-z\d@$!%*#?&-]{8,64}$/;
 
   return passwordRegex.test(value);
 }

--- a/src/utils/check.ts
+++ b/src/utils/check.ts
@@ -1,8 +1,8 @@
 export function checkEmailType(value: string) {
-  const emailRegax =
+  const emailRegex =
     /^(([^<>()\].,;:\s@"]+(\.[^<>()\].,;:\s@"]+)*)|(".+"))@(([^<>()[\].,;:\s@"]+\.)+[^<>()[\].,;:\s@"]{2,})$/i;
 
-  return emailRegax.test(value); // 형식에 맞는 경우 true 리턴
+  return emailRegex.test(value); // 형식에 맞는 경우 true 리턴
 }
 
 export function checkNicknameType(value: string) {
@@ -24,7 +24,7 @@ export function checkNicknameType(value: string) {
   }
 }
 export function checkPwdType(value: string) {
-  const passwordRegax = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{8,}$/;
+  const passwordRegex = /^(?=.*[a-zA-Z])((?=.*\d)(?=.*[!@#$%^&*-~])).{8,64}$/;
 
-  return passwordRegax.test(value);
+  return passwordRegex.test(value);
 }


### PR DESCRIPTION
## 📌 내용
<!-- 하고 싶은 말 자유롭게 -->
- regex 수정했습니다. 서버 에러 발생 가능성과 기디의 의견을 취합하여 큰 따옴표, 작은 따옴표, 백틱, 띄어쓰기, 역슬래쉬는 불가합니다.
- 추후 서버에서만 확인하는 것으로 변경될 예정입니다.
- 이 부분은 유저에게 바로 전달되는 것이므로 빠르게 머지합니다.

<br />

## 📌 내가 알게 된 부분
<!-- 새롭게 알게 된 부분을 적쟈 (기록하면서 개발하기!) -->
- `[ ]` 안에서 `.`은 모든 문자가 아니라 본래 .을 의미하는구나아!

<br />

## 📌 질문할 부분 
<!-- 작은 거라도 조아  -->
- 