### PR TITLE
periNote reflow 버그 개선

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "framer-motion": "^6.2.3",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-hook-form": "^7.25.3",
+    "react-hook-form": "^7.28.1",
     "react-responsive": "^9.0.0-beta.6",
     "react-router-dom": "^6.2.1",
     "react-scripts": "^5.0.0",

--- a/src/components/bookNote/periNote/PeriNote.tsx
+++ b/src/components/bookNote/periNote/PeriNote.tsx
@@ -39,7 +39,7 @@ export default function PeriNote() {
       ]
     >();
 
-  const { getValues, register } = useForm<FormData>();
+  const { getValues, register, setFocus } = useForm<FormData>();
 
   const { data, setData, isLoading } = useFetchNote<PeriNoteData>(userToken, `/review/${reviewId}/peri`, {
     answerThree: {
@@ -161,7 +161,6 @@ export default function PeriNote() {
 
   // 이거 마쟈..?
   useEffect(() => {
-    console.log("isChanged");
     // 질문이 모두 채워져 있으면 addQuestion의 isPrevented를 false
     if (data.answerThree.children.every((nodeList) => nodeList.content !== "")) {
       // 질문이 모두 채워진 상태에서 답변이 채워지면 모두 false
@@ -222,6 +221,7 @@ export default function PeriNote() {
                   onSetContent={handleSetContent}
                   onDeleteChild={handleDeleteChild}
                   register={register}
+                  setFocus={setFocus}
                 />
               </StArticle>
             ))}

--- a/src/components/bookNote/periNote/PeriNote.tsx
+++ b/src/components/bookNote/periNote/PeriNote.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-import { useForm } from "react-hook-form";
+import { useForm, UseFormRegister, UseFormSetFocus } from "react-hook-form";
 import { useOutletContext } from "react-router-dom";
 import styled, { css } from "styled-components";
 
@@ -22,6 +22,11 @@ export interface BookData {
 
 export interface FormData {
   [key: string]: string;
+}
+
+export interface FormController {
+  register: UseFormRegister<FormData>;
+  setFocus: UseFormSetFocus<FormData>;
 }
 
 export default function PeriNote() {
@@ -220,8 +225,7 @@ export default function PeriNote() {
                   onAddChild={handleAddChild}
                   onSetContent={handleSetContent}
                   onDeleteChild={handleDeleteChild}
-                  register={register}
-                  setFocus={setFocus}
+                  formController={{ register, setFocus }}
                 />
               </StArticle>
             ))}

--- a/src/components/bookNote/periNote/PeriNoteInput.tsx
+++ b/src/components/bookNote/periNote/PeriNoteInput.tsx
@@ -1,11 +1,10 @@
 import { useEffect } from "react";
-import { UseFormRegister, UseFormSetFocus } from "react-hook-form";
 import TextareaAutosize from "react-textarea-autosize";
 import styled, { css } from "styled-components";
 
 import theme from "../../../styles/theme";
 import { PeriNoteTreeNode } from "../../../utils/dataType";
-import { FormData } from "./PeriNote";
+import { FormController } from "./PeriNote";
 import { StAddAnswerButton, StMenu, StMenuBtn, StMoreIcon } from "./PriorQuestion";
 
 interface PeriNoteInputProps {
@@ -20,8 +19,7 @@ interface PeriNoteInputProps {
     index: number,
     isQuestion: boolean,
   ) => void;
-  register: UseFormRegister<FormData>;
-  setFocus: UseFormSetFocus<FormData>;
+  formController: FormController;
 }
 
 export const labelColorList = [
@@ -38,7 +36,8 @@ export const labelColorList = [
 ];
 
 export default function PeriNoteInput(props: PeriNoteInputProps) {
-  const { path, index, node, onAddChild, onDeleteChild, onAddChildByEnter, register, setFocus } = props;
+  const { path, index, node, onAddChild, onDeleteChild, onAddChildByEnter, formController } = props;
+  const { register, setFocus } = formController;
   const isQuestion = node.type === "question";
   const inputKey = `${path.join(",")}`;
   const labelColor = labelColorList[(path.length - 1) % 10];
@@ -102,8 +101,7 @@ export default function PeriNoteInput(props: PeriNoteInputProps) {
               onAddChild={(p, i, isQ) => onAddChild(p, i, isQ)}
               onDeleteChild={(p) => onDeleteChild(p)}
               onAddChildByEnter={(e, p, i, isQ) => onAddChildByEnter(e, p, i, isQ)}
-              register={register}
-              setFocus={setFocus}
+              formController={formController}
             />
           ))}
       </StFieldWrapper>

--- a/src/components/bookNote/periNote/PeriNoteInput.tsx
+++ b/src/components/bookNote/periNote/PeriNoteInput.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useRef } from "react";
+import { useForm, UseFormRegister } from "react-hook-form";
 import TextareaAutosize from "react-textarea-autosize";
 import styled, { css } from "styled-components";
 
 import theme from "../../../styles/theme";
 import { PeriNoteTreeNode } from "../../../utils/dataType";
+import { FormData } from "./PeriNote";
 import { StAddAnswerButton, StMenu, StMenuBtn, StMoreIcon } from "./PriorQuestion";
 
 interface PeriNoteInputProps {
@@ -11,7 +13,6 @@ interface PeriNoteInputProps {
   index: number;
   node: PeriNoteTreeNode;
   onAddChild: (path: number[], index: number, isQuestion: boolean) => void;
-  onSetContent: (value: string, path: number[]) => void;
   onDeleteChild: (path: number[]) => void;
   onAddChildByEnter: (
     e: React.KeyboardEvent<HTMLTextAreaElement>,
@@ -19,6 +20,7 @@ interface PeriNoteInputProps {
     index: number,
     isQuestion: boolean,
   ) => void;
+  register: UseFormRegister<FormData>;
 }
 
 export const labelColorList = [
@@ -35,17 +37,13 @@ export const labelColorList = [
 ];
 
 export default function PeriNoteInput(props: PeriNoteInputProps) {
-  const { path, index, node, onAddChild, onSetContent, onDeleteChild, onAddChildByEnter } = props;
+  const { path, index, node, onAddChild, onDeleteChild, onAddChildByEnter, register } = props;
   const isQuestion = node.type === "question";
 
   const labelColor = labelColorList[(path.length - 1) % 10];
-  const textAreaRef = useRef<HTMLTextAreaElement>(null);
+  // const textAreaRef = useRef<HTMLTextAreaElement>(null);
 
-  const handleChangeSetContent = (e: React.ChangeEvent<HTMLTextAreaElement>, pathArray: number[]) => {
-    if (e.target.value !== "\n") {
-      onSetContent(e.target.value, pathArray);
-    }
-  };
+  // const textAreaRef = register(`${path.join(",")}`, { shouldUnregister: true });
 
   const addChildByEnter = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === "Enter" && !e.shiftKey) {
@@ -54,11 +52,11 @@ export default function PeriNoteInput(props: PeriNoteInputProps) {
     }
   };
 
-  useEffect(() => {
-    if (textAreaRef.current) {
-      textAreaRef.current.focus();
-    }
-  }, []);
+  // useEffect(() => {
+  //   if (textAreaRef.current) {
+  //     textAreaRef.current.focus();
+  //   }
+  // }, []);
 
   return (
     <>
@@ -71,10 +69,11 @@ export default function PeriNoteInput(props: PeriNoteInputProps) {
         )}
         <StInputWrapper isanswer={!isQuestion}>
           <StInput
-            ref={textAreaRef}
-            value={node.content}
+            {...register(`${path.join(",")}`, {
+              shouldUnregister: true,
+            })}
+            defaultValue={node.content}
             placeholder={`${isQuestion ? "질문" : "답변"}을 입력해주세요.`}
-            onChange={(e) => handleChangeSetContent(e, path)}
             onKeyPress={addChildByEnter}
           />
           {isQuestion && (
@@ -104,9 +103,9 @@ export default function PeriNoteInput(props: PeriNoteInputProps) {
               index={i}
               node={node}
               onAddChild={(p, i, isQ) => onAddChild(p, i, isQ)}
-              onSetContent={(v, p) => onSetContent(v, p)}
               onDeleteChild={(p) => onDeleteChild(p)}
               onAddChildByEnter={(e, p, i, isQ) => onAddChildByEnter(e, p, i, isQ)}
+              register={register}
             />
           ))}
       </StFieldWrapper>

--- a/src/components/bookNote/periNote/PeriNoteInput.tsx
+++ b/src/components/bookNote/periNote/PeriNoteInput.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useRef } from "react";
-import { useForm, UseFormRegister } from "react-hook-form";
+import { useEffect } from "react";
+import { UseFormRegister, UseFormSetFocus } from "react-hook-form";
 import TextareaAutosize from "react-textarea-autosize";
 import styled, { css } from "styled-components";
 
@@ -21,6 +21,7 @@ interface PeriNoteInputProps {
     isQuestion: boolean,
   ) => void;
   register: UseFormRegister<FormData>;
+  setFocus: UseFormSetFocus<FormData>;
 }
 
 export const labelColorList = [
@@ -37,26 +38,22 @@ export const labelColorList = [
 ];
 
 export default function PeriNoteInput(props: PeriNoteInputProps) {
-  const { path, index, node, onAddChild, onDeleteChild, onAddChildByEnter, register } = props;
+  const { path, index, node, onAddChild, onDeleteChild, onAddChildByEnter, register, setFocus } = props;
   const isQuestion = node.type === "question";
-
+  const inputKey = `${path.join(",")}`;
   const labelColor = labelColorList[(path.length - 1) % 10];
-  // const textAreaRef = useRef<HTMLTextAreaElement>(null);
-
-  // const textAreaRef = register(`${path.join(",")}`, { shouldUnregister: true });
 
   const addChildByEnter = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
       // 꼬리질문과 답변은 자신의 아래에 추가하는 것이 아닌 자신의 부모의 children에 추가해야함
       onAddChild(path.slice(0, -1), index, isQuestion);
     }
   };
 
-  // useEffect(() => {
-  //   if (textAreaRef.current) {
-  //     textAreaRef.current.focus();
-  //   }
-  // }, []);
+  useEffect(() => {
+    setFocus(inputKey);
+  }, [setFocus]);
 
   return (
     <>
@@ -69,7 +66,7 @@ export default function PeriNoteInput(props: PeriNoteInputProps) {
         )}
         <StInputWrapper isanswer={!isQuestion}>
           <StInput
-            {...register(`${path.join(",")}`, {
+            {...register(inputKey, {
               shouldUnregister: true,
             })}
             defaultValue={node.content}
@@ -106,6 +103,7 @@ export default function PeriNoteInput(props: PeriNoteInputProps) {
               onDeleteChild={(p) => onDeleteChild(p)}
               onAddChildByEnter={(e, p, i, isQ) => onAddChildByEnter(e, p, i, isQ)}
               register={register}
+              setFocus={setFocus}
             />
           ))}
       </StFieldWrapper>

--- a/src/components/bookNote/periNote/PriorAnswer.tsx
+++ b/src/components/bookNote/periNote/PriorAnswer.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from "react";
-import { UseFormRegister } from "react-hook-form";
+import { UseFormRegister, UseFormSetFocus } from "react-hook-form";
 import TextareaAutosize from "react-textarea-autosize";
 import styled, { css } from "styled-components";
 
@@ -17,10 +17,11 @@ interface PriorAnswerProps {
   onSetContent: (value: string, path: number[]) => void;
   onDeleteChild: (path: number[]) => void;
   register: UseFormRegister<FormData>;
+  setFocus: UseFormSetFocus<FormData>;
 }
 
 export default function PriorAnswer(props: PriorAnswerProps) {
-  const { path, index, node, onAddChild, onSetContent, onDeleteChild, register } = props;
+  const { path, index, node, onAddChild, onSetContent, onDeleteChild, register, setFocus } = props;
   const isQuestion = false;
 
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
@@ -94,6 +95,7 @@ export default function PriorAnswer(props: PriorAnswerProps) {
             onDeleteChild={(p) => onDeleteChild(p)}
             onAddChildByEnter={(e, p, i, isQ) => handleKeyPress(e, p, i, isQ)}
             register={register}
+            setFocus={setFocus}
           />
         ))}
     </StFieldset>

--- a/src/components/bookNote/periNote/PriorAnswer.tsx
+++ b/src/components/bookNote/periNote/PriorAnswer.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useRef } from "react";
+import { UseFormRegister } from "react-hook-form";
 import TextareaAutosize from "react-textarea-autosize";
 import styled, { css } from "styled-components";
 
 import { IcPeriAnswer } from "../../../assets/icons";
 import { PeriNoteTreeNode } from "../../../utils/dataType";
 import { PeriNoteInput } from "..";
+import { FormData } from "./PeriNote";
 import { StMenu, StMenuBtn, StMoreIcon } from "./PriorQuestion";
 
 interface PriorAnswerProps {
@@ -14,10 +16,11 @@ interface PriorAnswerProps {
   onAddChild: (path: number[], index: number, isQuestion: boolean) => void;
   onSetContent: (value: string, path: number[]) => void;
   onDeleteChild: (path: number[]) => void;
+  register: UseFormRegister<FormData>;
 }
 
 export default function PriorAnswer(props: PriorAnswerProps) {
-  const { path, index, node, onAddChild, onSetContent, onDeleteChild } = props;
+  const { path, index, node, onAddChild, onSetContent, onDeleteChild, register } = props;
   const isQuestion = false;
 
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
@@ -88,9 +91,9 @@ export default function PriorAnswer(props: PriorAnswerProps) {
             index={i}
             node={node}
             onAddChild={(p, i, isQ) => handleClickAddChild(p, i, isQ)}
-            onSetContent={(v, p) => onSetContent(v, p)}
             onDeleteChild={(p) => onDeleteChild(p)}
             onAddChildByEnter={(e, p, i, isQ) => handleKeyPress(e, p, i, isQ)}
+            register={register}
           />
         ))}
     </StFieldset>

--- a/src/components/bookNote/periNote/PriorAnswer.tsx
+++ b/src/components/bookNote/periNote/PriorAnswer.tsx
@@ -1,12 +1,11 @@
 import { useEffect, useRef } from "react";
-import { UseFormRegister, UseFormSetFocus } from "react-hook-form";
 import TextareaAutosize from "react-textarea-autosize";
 import styled, { css } from "styled-components";
 
 import { IcPeriAnswer } from "../../../assets/icons";
 import { PeriNoteTreeNode } from "../../../utils/dataType";
 import { PeriNoteInput } from "..";
-import { FormData } from "./PeriNote";
+import { FormController } from "./PeriNote";
 import { StMenu, StMenuBtn, StMoreIcon } from "./PriorQuestion";
 
 interface PriorAnswerProps {
@@ -16,12 +15,11 @@ interface PriorAnswerProps {
   onAddChild: (path: number[], index: number, isQuestion: boolean) => void;
   onSetContent: (value: string, path: number[]) => void;
   onDeleteChild: (path: number[]) => void;
-  register: UseFormRegister<FormData>;
-  setFocus: UseFormSetFocus<FormData>;
+  formController: FormController;
 }
 
 export default function PriorAnswer(props: PriorAnswerProps) {
-  const { path, index, node, onAddChild, onSetContent, onDeleteChild, register, setFocus } = props;
+  const { path, index, node, onAddChild, onSetContent, onDeleteChild, formController } = props;
   const isQuestion = false;
 
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
@@ -94,8 +92,7 @@ export default function PriorAnswer(props: PriorAnswerProps) {
             onAddChild={(p, i, isQ) => handleClickAddChild(p, i, isQ)}
             onDeleteChild={(p) => onDeleteChild(p)}
             onAddChildByEnter={(e, p, i, isQ) => handleKeyPress(e, p, i, isQ)}
-            register={register}
-            setFocus={setFocus}
+            formController={formController}
           />
         ))}
     </StFieldset>

--- a/src/components/bookNote/periNote/PriorQuestion.tsx
+++ b/src/components/bookNote/periNote/PriorQuestion.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from "react";
+import { UseFormRegister } from "react-hook-form";
 import TextareaAutosize from "react-textarea-autosize";
 import styled from "styled-components";
 
@@ -6,6 +7,7 @@ import { IcMore, IcPeriQuestion } from "../../../assets/icons";
 import { PeriNoteTreeNode } from "../../../utils/dataType";
 import { Button } from "../../common/styled/Button";
 import { PriorAnswer } from "..";
+import { FormData } from "./PeriNote";
 
 interface PriorQuestionProps {
   path: number[];
@@ -14,10 +16,11 @@ interface PriorQuestionProps {
   onAddChild: (path: number[], currentIndex: number, isQuestion: boolean) => void;
   onSetContent: (value: string, path: number[]) => void;
   onDeleteChild: (path: number[]) => void;
+  register: UseFormRegister<FormData>;
 }
 
 export default function PriorQuestion(props: PriorQuestionProps) {
-  const { path, index, node, onAddChild, onSetContent, onDeleteChild } = props;
+  const { path, index, node, onAddChild, onSetContent, onDeleteChild, register } = props;
   // 답변 추가 시 사용되는 변수라서 isQuestion false인 것
   const isQuestion = false;
 
@@ -76,6 +79,7 @@ export default function PriorQuestion(props: PriorQuestionProps) {
             onAddChild={(p, i, isQ) => onAddChild(p, i, isQ)}
             onSetContent={(v, p) => onSetContent(v, p)}
             onDeleteChild={(p) => onDeleteChild(p)}
+            register={register}
           />
         ))}
     </>

--- a/src/components/bookNote/periNote/PriorQuestion.tsx
+++ b/src/components/bookNote/periNote/PriorQuestion.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from "react";
-import { UseFormRegister } from "react-hook-form";
+import { UseFormRegister, UseFormSetFocus } from "react-hook-form";
 import TextareaAutosize from "react-textarea-autosize";
 import styled from "styled-components";
 
@@ -17,10 +17,11 @@ interface PriorQuestionProps {
   onSetContent: (value: string, path: number[]) => void;
   onDeleteChild: (path: number[]) => void;
   register: UseFormRegister<FormData>;
+  setFocus: UseFormSetFocus<FormData>;
 }
 
 export default function PriorQuestion(props: PriorQuestionProps) {
-  const { path, index, node, onAddChild, onSetContent, onDeleteChild, register } = props;
+  const { path, index, node, onAddChild, onSetContent, onDeleteChild, register, setFocus } = props;
   // 답변 추가 시 사용되는 변수라서 isQuestion false인 것
   const isQuestion = false;
 
@@ -34,9 +35,7 @@ export default function PriorQuestion(props: PriorQuestionProps) {
 
   const handleKeyPress = (e: React.KeyboardEvent<HTMLTextAreaElement>, pathArray: number[]) => {
     if (e.key === "Enter" && !e.shiftKey) {
-      if (!e.shiftKey) {
-        onAddChild(pathArray, node.children.length - 1, isQuestion);
-      }
+      onAddChild(pathArray, node.children.length - 1, isQuestion);
     }
   };
 
@@ -80,6 +79,7 @@ export default function PriorQuestion(props: PriorQuestionProps) {
             onSetContent={(v, p) => onSetContent(v, p)}
             onDeleteChild={(p) => onDeleteChild(p)}
             register={register}
+            setFocus={setFocus}
           />
         ))}
     </>

--- a/src/components/bookNote/periNote/PriorQuestion.tsx
+++ b/src/components/bookNote/periNote/PriorQuestion.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useRef } from "react";
-import { UseFormRegister, UseFormSetFocus } from "react-hook-form";
 import TextareaAutosize from "react-textarea-autosize";
 import styled from "styled-components";
 
@@ -7,7 +6,7 @@ import { IcMore, IcPeriQuestion } from "../../../assets/icons";
 import { PeriNoteTreeNode } from "../../../utils/dataType";
 import { Button } from "../../common/styled/Button";
 import { PriorAnswer } from "..";
-import { FormData } from "./PeriNote";
+import { FormController } from "./PeriNote";
 
 interface PriorQuestionProps {
   path: number[];
@@ -16,12 +15,11 @@ interface PriorQuestionProps {
   onAddChild: (path: number[], currentIndex: number, isQuestion: boolean) => void;
   onSetContent: (value: string, path: number[]) => void;
   onDeleteChild: (path: number[]) => void;
-  register: UseFormRegister<FormData>;
-  setFocus: UseFormSetFocus<FormData>;
+  formController: FormController;
 }
 
 export default function PriorQuestion(props: PriorQuestionProps) {
-  const { path, index, node, onAddChild, onSetContent, onDeleteChild, register, setFocus } = props;
+  const { path, index, node, onAddChild, onSetContent, onDeleteChild, formController } = props;
   // 답변 추가 시 사용되는 변수라서 isQuestion false인 것
   const isQuestion = false;
 
@@ -78,8 +76,7 @@ export default function PriorQuestion(props: PriorQuestionProps) {
             onAddChild={(p, i, isQ) => onAddChild(p, i, isQ)}
             onSetContent={(v, p) => onSetContent(v, p)}
             onDeleteChild={(p) => onDeleteChild(p)}
-            register={register}
-            setFocus={setFocus}
+            formController={formController}
           />
         ))}
     </>

--- a/yarn.lock
+++ b/yarn.lock
@@ -7110,10 +7110,10 @@ react-error-overlay@^6.0.10:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.10.tgz#0fe26db4fa85d9dbb8624729580e90e7159a59a6"
   integrity sha512-mKR90fX7Pm5seCOfz8q9F+66VCc1PGsWSBxKbITjfKVQHMNF2zudxHnMdJiB1fRCb+XsbQV9sO9DCkgsMQgBIA==
 
-react-hook-form@^7.25.3:
-  version "7.25.3"
-  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.25.3.tgz#1475fd52398e905e1f6d88835f96aaa1144635c3"
-  integrity sha512-jL4SByMaC8U3Vhu9s7CwgJBP4M6I3Kpwxib9LrCwWSRPnXDrNQL4uihSTqLLoDICqSUhwwvian9uVYfv+ITtGg==
+react-hook-form@^7.28.1:
+  version "7.28.1"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.28.1.tgz#95fc37be6c6b9d57212eb7eca055fb36d079b3b7"
+  integrity sha512-mgwxvXuvt3FMY/mdnWbPc++Zf1U5xYzkhOaL05mtFMLvXc9MvUhMUlKtUVuO12sOrgT3nPXBgVFawtiJ4ONrgg==
 
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"


### PR DESCRIPTION
## 📌 내용
<!-- 하고 싶은 말 자유롭게 -->
- 독서 중의 모든 내용이 하나의 state로 관리되면서 reflow 문제가 발생하고 버벅임이 심했던 부분을 개선했습니다.
- 북노트... 이제 보내준다.... 후
- 커밋은 4개지만, 의미있는 단위로 나눈 것이고, 정말 며칠동안 소령이가 아주 많이 고민한 내용들..!
- useForm 추가했습니답

<br />

## 📌 내가 알게 된 부분
<!-- 새롭게 알게 된 부분을 적쟈 (기록하면서 개발하기!) -->
- state로 꼭 관리해야하는 것들만 useState를 사용하자. 상태 변화를 계속 지켜보고 control 할 필요가 없다면, 낭비하지말자.. 관련한 워닝은 아래 첨부부.. 리플로우..
<img width="431" alt="image" src="https://user-images.githubusercontent.com/40630964/160256418-1decc67b-e49f-4043-a169-26178b0c2f27.png">
- onKeypress 부분에서 엔터를 막고 싶다면 `e.preventDefault();`를 쓰면 된다. enter의 default 기능은 사실 submit도 뭣도 아닌 엔터니까.. 바보..
- useForm을 잘 활용하면 다양한 것을 할 수 있따. 꽤 잘 만들어진 듯!

<br />

## 📌 질문할 부분 
<!-- 작은 거라도 조아  -->
- 있을리가 ㅋ