### PR TITLE
feat: 네트워크 유실 시 토스트 메시지 변경(책 추가 페이지)

### DIFF
--- a/src/components/addBook/AlertToast.tsx
+++ b/src/components/addBook/AlertToast.tsx
@@ -1,22 +1,23 @@
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 
 import { IcToastAlert } from "../../assets/icons";
 import { StIcCancelWhite } from "../common/styled/NoteModalWrapper";
 
 interface AlertToastProps {
   onCloseAlertToast: () => void;
+  isServerError: boolean;
 }
 
 export default function AlertToast(props: AlertToastProps) {
-  const { onCloseAlertToast } = props;
+  const { onCloseAlertToast, isServerError } = props;
 
   return (
     <StSaveWrapper>
-      <StIconTextWrapper>
+      <StIconTextWrapper isError={isServerError}>
         <IcToastAlert />
         <div>
-          <StToastH1>이미 추가된 책입니다.</StToastH1>
-          <StToastSpan>다른 책을 추가해주세요</StToastSpan>
+          <StToastH1>{isServerError ? "저장에 실패했습니다" : "이미 추가된 책입니다."}</StToastH1>
+          <StToastSpan>{isServerError ? "네트워크 연결을 확인해주세요" : "다른 책을 추가해주세요"}</StToastSpan>
         </div>
       </StIconTextWrapper>
       <StIcCancel onClick={onCloseAlertToast} />
@@ -45,9 +46,20 @@ const StSaveWrapper = styled.div`
   color: ${({ theme }) => theme.colors.gray200};
 `;
 
-const StIconTextWrapper = styled.div`
+const StIconTextWrapper = styled.div<{ isError: boolean }>`
   display: flex;
   column-gap: 1.3rem;
+
+  ${({ isError }) =>
+    isError
+      ? css`
+          & > svg {
+            rect {
+              fill: #e35b55;
+            }
+          }
+        `
+      : ""}
 `;
 
 const StToastH1 = styled.h1`

--- a/src/components/addBook/AlertToast.tsx
+++ b/src/components/addBook/AlertToast.tsx
@@ -18,7 +18,7 @@ export default function AlertToast(props: AlertToastProps) {
         <IcToastAlert />
         <div>
           <StToastH1>{error ? "저장에 실패했습니다" : exist ? message : null}</StToastH1>
-          <StToastSpan>{error ? "네트워크를 확인해주세요" : exist ? "다른 책을 추가해주세요" : null}</StToastSpan>
+          <StToastSpan>{error ? message : exist ? "다른 책을 추가해주세요" : null}</StToastSpan>
         </div>
       </StIconTextWrapper>
       <StIcCancel onClick={onCloseAlertToast} />

--- a/src/components/addBook/AlertToast.tsx
+++ b/src/components/addBook/AlertToast.tsx
@@ -5,19 +5,20 @@ import { StIcCancelWhite } from "../common/styled/NoteModalWrapper";
 
 interface AlertToastProps {
   onCloseAlertToast: () => void;
-  isServerError: boolean;
+  isServerError: any;
 }
 
 export default function AlertToast(props: AlertToastProps) {
   const { onCloseAlertToast, isServerError } = props;
+  const { error, exist, message } = isServerError;
 
   return (
     <StSaveWrapper>
-      <StIconTextWrapper isError={isServerError}>
+      <StIconTextWrapper isError={error}>
         <IcToastAlert />
         <div>
-          <StToastH1>{isServerError ? "저장에 실패했습니다" : "이미 추가된 책입니다."}</StToastH1>
-          <StToastSpan>{isServerError ? "네트워크 연결을 확인해주세요" : "다른 책을 추가해주세요"}</StToastSpan>
+          <StToastH1>{error ? "저장에 실패했습니다" : exist ? message : null}</StToastH1>
+          <StToastSpan>{error ? "네트워크를 확인해주세요" : exist ? "다른 책을 추가해주세요" : null}</StToastSpan>
         </div>
       </StIconTextWrapper>
       <StIcCancel onClick={onCloseAlertToast} />

--- a/src/components/addBook/BookList.tsx
+++ b/src/components/addBook/BookList.tsx
@@ -41,24 +41,23 @@ export default function BookList(props: BookListProps) {
 
   const handleClickBookCard = (isbn: string) => {
     if (!isLogin) return setSelectedBookIsbn(isbn);
-    else {
-      checkIsBookExist(isbn).then((result) => {
-        const { isError, isExist, message } = result;
 
-        setIsServerError((prev) => {
-          return { ...prev, error: isError, exist: isExist, message };
-        });
+    checkIsBookExist(isbn).then((result) => {
+      const { isError, isExist, message } = result;
 
-        if (isError || isExist) {
-          // 에러가 존재할 경우
-          // 에러 토스트 띄우기 - 모종의 이유로 실패한 경우
-          setAlertToastOpen(true);
-        } else {
-          // 모든 상황을 통과
-          setSelectedBookIsbn(isbn);
-        }
+      setIsServerError((prev) => {
+        return { ...prev, error: isError, exist: isExist, message };
       });
-    }
+
+      if (isError || isExist) {
+        // 에러가 존재할 경우
+        // 에러 토스트 띄우기 - 모종의 이유로 실패한 경우
+        setAlertToastOpen(true);
+      } else {
+        // 모든 상황을 통과
+        setSelectedBookIsbn(isbn);
+      }
+    });
   };
 
   useAlertToast(alertToastOpen, () => setAlertToastOpen(false));

--- a/src/components/addBook/BookList.tsx
+++ b/src/components/addBook/BookList.tsx
@@ -18,6 +18,7 @@ export default function BookList(props: BookListProps) {
   // default is false
   const [alertToastOpen, setAlertToastOpen] = useState<boolean>(false);
   const [selectedBookIsbn, setSelectedBookIsbn] = useState<string>("");
+  const [serverError, setServerError] = useState<boolean>(false);
 
   const closeAlertToast = () => {
     setAlertToastOpen(false);
@@ -34,7 +35,8 @@ export default function BookList(props: BookListProps) {
       checkIsBookExist(isbn).then((result) => {
         if (result.isError) {
           // 에러 토스트 띄우기 - 모종의 이유로 실패한 경우
-          return;
+          setAlertToastOpen(true);
+          setServerError(true);
         } else if (result.isExist) {
           // 통신에 성공 - 책이 중복된 경우
           setAlertToastOpen(true);
@@ -50,6 +52,7 @@ export default function BookList(props: BookListProps) {
     if (alertToastOpen) {
       const saveToast = setTimeout(() => {
         setAlertToastOpen(false);
+        setServerError(false);
       }, 2000);
 
       return () => {
@@ -71,7 +74,7 @@ export default function BookList(props: BookListProps) {
           onResetSelectedBookIsbn={resetSelectedBookIsbn}
         />
       ))}
-      {alertToastOpen ? <AlertToast onCloseAlertToast={closeAlertToast} /> : null}
+      {alertToastOpen ? <AlertToast onCloseAlertToast={closeAlertToast} isServerError={serverError} /> : null}
     </StListWrapper>
   );
 }

--- a/src/components/addBook/BookList.tsx
+++ b/src/components/addBook/BookList.tsx
@@ -13,13 +13,23 @@ interface BookListProps {
   books: BookInfo[];
 }
 
+interface ServerError {
+  error: boolean;
+  exist: boolean;
+  message: string;
+}
+
 export default function BookList(props: BookListProps) {
   const { isLogin, books } = props;
 
   // default is false
   const [alertToastOpen, setAlertToastOpen] = useState<boolean>(false);
   const [selectedBookIsbn, setSelectedBookIsbn] = useState<string>("");
-  const [isServerError, setIsServerError] = useState<boolean>(false);
+  const [isServerError, setIsServerError] = useState<ServerError>({
+    error: false,
+    exist: false,
+    message: "",
+  });
 
   const closeAlertToast = () => {
     setAlertToastOpen(false);
@@ -31,29 +41,27 @@ export default function BookList(props: BookListProps) {
 
   const handleClickBookCard = (isbn: string) => {
     if (!isLogin) return setSelectedBookIsbn(isbn);
+    else {
+      checkIsBookExist(isbn).then((result) => {
+        const { isError, isExist, message } = result;
 
-    checkIsBookExist(isbn).then((result) => {
-      categorizeToast(result.isError, result.isExist, isbn);
-    });
-  };
+        setIsServerError((prev) => {
+          return { ...prev, error: isError, exist: isExist, message };
+        });
 
-  const categorizeToast = (isError: boolean, isExist: boolean, isbn: string) => {
-    if (isError) {
-      // 에러 토스트 띄우기 - 모종의 이유로 실패한 경우
-      setAlertToastOpen(true);
-      setIsServerError(true);
-    } else if (isExist) {
-      // 통신에 성공 - 책이 중복된 경우
-      setAlertToastOpen(true);
-    } else {
-      // 모든 상황을 통과
-      setSelectedBookIsbn(isbn);
+        if (isError || isExist) {
+          // 에러가 존재할 경우
+          // 에러 토스트 띄우기 - 모종의 이유로 실패한 경우
+          setAlertToastOpen(true);
+        } else {
+          // 모든 상황을 통과
+          setSelectedBookIsbn(isbn);
+        }
+      });
     }
   };
 
-
   useAlertToast(alertToastOpen, () => setAlertToastOpen(false));
-
 
   if (books.length === 0) return <BookEmpty />;
 

--- a/src/components/addBook/BookList.tsx
+++ b/src/components/addBook/BookList.tsx
@@ -19,7 +19,7 @@ export default function BookList(props: BookListProps) {
   // default is false
   const [alertToastOpen, setAlertToastOpen] = useState<boolean>(false);
   const [selectedBookIsbn, setSelectedBookIsbn] = useState<string>("");
-  const [serverError, setServerError] = useState<boolean>(false);
+  const [isServerError, setIsServerError] = useState<boolean>(false);
 
   const closeAlertToast = () => {
     setAlertToastOpen(false);
@@ -30,22 +30,24 @@ export default function BookList(props: BookListProps) {
   };
 
   const handleClickBookCard = (isbn: string) => {
-    if (!isLogin) {
-      setSelectedBookIsbn(isbn);
+    if (!isLogin) return setSelectedBookIsbn(isbn);
+
+    checkIsBookExist(isbn).then((result) => {
+      categorizeToast(result.isError, result.isExist, isbn);
+    });
+  };
+
+  const categorizeToast = (isError: boolean, isExist: boolean, isbn: string) => {
+    if (isError) {
+      // 에러 토스트 띄우기 - 모종의 이유로 실패한 경우
+      setAlertToastOpen(true);
+      setIsServerError(true);
+    } else if (isExist) {
+      // 통신에 성공 - 책이 중복된 경우
+      setAlertToastOpen(true);
     } else {
-      checkIsBookExist(isbn).then((result) => {
-        if (result.isError) {
-          // 에러 토스트 띄우기 - 모종의 이유로 실패한 경우
-          setAlertToastOpen(true);
-          setServerError(true);
-        } else if (result.isExist) {
-          // 통신에 성공 - 책이 중복된 경우
-          setAlertToastOpen(true);
-        } else {
-          // 모든 상황을 통과
-          setSelectedBookIsbn(isbn);
-        }
-      });
+      // 모든 상황을 통과
+      setSelectedBookIsbn(isbn);
     }
   };
 
@@ -66,7 +68,7 @@ export default function BookList(props: BookListProps) {
           onResetSelectedBookIsbn={resetSelectedBookIsbn}
         />
       ))}
-      {alertToastOpen ? <AlertToast onCloseAlertToast={closeAlertToast} isServerError={serverError} /> : null}
+      {alertToastOpen ? <AlertToast onCloseAlertToast={closeAlertToast} isServerError={isServerError} /> : null}
     </StListWrapper>
   );
 }

--- a/src/components/signup/ThirdStep.tsx
+++ b/src/components/signup/ThirdStep.tsx
@@ -35,9 +35,7 @@ export default function ThirdStep() {
   }, [isLogin]);
 
   const postSignup = async () => {
-    const res = await postData("/auth/signup", userData);
-
-    console.log(res);
+    await postData("/auth/signup", userData);
   };
 
   const postLogin = async () => {

--- a/src/utils/lib/api.ts
+++ b/src/utils/lib/api.ts
@@ -75,7 +75,6 @@ export const checkIsBookExist = async (isbn: string) => {
   try {
     const { data } = await client(userToken).get(`/book/exist/${isbn}`);
 
-    console.log(data);
     if (data.success) {
       return { isError: false, isExist: data.data.isExist, message: data.message };
     } else {

--- a/src/utils/lib/api.ts
+++ b/src/utils/lib/api.ts
@@ -85,8 +85,7 @@ export const checkIsBookExist = async (isbn: string) => {
     }
   } catch (err) {
     // 통신에 실패한 경우
-    console.log(err);
 
-    return { isError: true, isExist: false, message: "df" };
+    return { isError: true, isExist: false, message: "네트워크를 확인해주세요" };
   }
 };

--- a/src/utils/lib/api.ts
+++ b/src/utils/lib/api.ts
@@ -64,25 +64,20 @@ export function useGetBookInfo(key: string) {
 export const checkIsBookExist = async (isbn: string) => {
   const _token = localStorage.getItem("booktez-token");
   const userToken = _token ? _token : "";
+  const { data } = await client(userToken).get(`/book/exist/${isbn}`);
+  const { message } = data;
 
   try {
-    const { data } = await client(userToken).get(`/book/exist/${isbn}`);
-
     if (data.success) {
-      return { isError: false, isExist: data.data.isExist };
+      return { isError: false, isExist: data.data.isExist, message };
     } else {
       // 통신에는 성공했으나 에러가 난 경우
       // 에러 메시지 받아서 토스트 띄울 수 있도록 추후 변경 예정
-      // console.log("[ERROR RETURNED]", data);
-
-      return { isError: true, isExist: false };
+      return { isError: true, isExist: false, message };
     }
   } catch (err) {
     // 통신에 실패한 경우
-    // if (axios.isAxiosError(err)) {
-    //   console.log("[ERROR CATCHED] statusCode: ", err.response?.status, err.message);
-    // }
 
-    return { isError: true, isExist: false };
+    return { isError: true, isExist: false, message };
   }
 };

--- a/src/utils/lib/api.ts
+++ b/src/utils/lib/api.ts
@@ -1,8 +1,15 @@
+import { useState } from "react";
 import useSWR from "swr";
 
 import { BookcaseInfo } from "../../pages/Bookcase";
 import { KAKAOParams, PatchBody, PeriNoteData, PostBody, PreNoteData } from "../dataType";
 import { client, KAKAO } from ".";
+
+interface ServerError {
+  error: boolean;
+  exist: boolean;
+  message: string;
+}
 
 export const searchBook = (params: KAKAOParams) => {
   return KAKAO.get("/v3/search/book", { params });
@@ -64,20 +71,22 @@ export function useGetBookInfo(key: string) {
 export const checkIsBookExist = async (isbn: string) => {
   const _token = localStorage.getItem("booktez-token");
   const userToken = _token ? _token : "";
-  const { data } = await client(userToken).get(`/book/exist/${isbn}`);
-  const { message } = data;
 
   try {
+    const { data } = await client(userToken).get(`/book/exist/${isbn}`);
+
+    console.log(data);
     if (data.success) {
-      return { isError: false, isExist: data.data.isExist, message };
+      return { isError: false, isExist: data.data.isExist, message: data.message };
     } else {
       // 통신에는 성공했으나 에러가 난 경우
       // 에러 메시지 받아서 토스트 띄울 수 있도록 추후 변경 예정
-      return { isError: true, isExist: false, message };
+      return { isError: true, isExist: false, message: data.message };
     }
   } catch (err) {
     // 통신에 실패한 경우
+    console.log(err);
 
-    return { isError: true, isExist: false, message };
+    return { isError: true, isExist: false, message: "df" };
   }
 };

--- a/src/utils/lib/api.ts
+++ b/src/utils/lib/api.ts
@@ -1,4 +1,3 @@
-import axios from "axios";
 import useSWR from "swr";
 
 import { BookcaseInfo } from "../../pages/Bookcase";
@@ -73,15 +72,16 @@ export const checkIsBookExist = async (isbn: string) => {
       return { isError: false, isExist: data.data.isExist };
     } else {
       // 통신에는 성공했으나 에러가 난 경우
-      console.log("[ERROR RETURNED]", data);
+      // 에러 메시지 받아서 토스트 띄울 수 있도록 추후 변경 예정
+      // console.log("[ERROR RETURNED]", data);
 
       return { isError: true, isExist: false };
     }
   } catch (err) {
     // 통신에 실패한 경우
-    if (axios.isAxiosError(err)) {
-      console.log("[ERROR CATCHED] statusCode: ", err.response?.status, err.message);
-    }
+    // if (axios.isAxiosError(err)) {
+    //   console.log("[ERROR CATCHED] statusCode: ", err.response?.status, err.message);
+    // }
 
     return { isError: true, isExist: false };
   }


### PR DESCRIPTION
## 📌 내용
<!-- 하고 싶은 말 자유롭게 -->
- state를 추가하여 책 추가 페이지에서 네트워크 유실 시 토스트 메시지를 변경하였습니다.
- 기존에 있던 토스트 양식을 그대로 이용하였고 svg { rect { fill } } 컬러만 변경해주었습니다.

<br />

## 📌 내가 알게 된 부분
<!-- 새롭게 알게 된 부분을 적쟈 (기록하면서 개발하기!) -->
- 와이파이 끄고 네트워크 유실 확인하기!
<img width="676" alt="스크린샷 2022-05-12 20 33 53" src="https://user-images.githubusercontent.com/87220517/168066488-b63673b5-e7f0-471f-b6cd-01cf4879ac9a.png">

<br />

## 📌 질문할 부분 
<!-- 작은 거라도 조아  -->
- 북 노트 부분에서도 토스트 메시지를 띄어야 하는 것으로 알고 있는데 사실 북노트가 소령님 원툴이다 보니 쉽사리 건들지 못할 것 같습니다. 혹시 다른 곳에서도 띄어야 한다면 말씀해 주시면 이 브랜치에 push 하겠습니다

-- 05.19
제가 이것저것 만져서 에러 잡아보려고 하는 중인데, 이전 커밋에서는 와이파이 끄고 네트워크 오류 잡았었는데 이번에는 잘 안되네요.. 어떻게 해결해야하는지 잘 모르겠어요 알려주실분!!